### PR TITLE
Fix form reveal and package release 0.47.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1146,6 +1146,12 @@
         "key": "ctrl+alt+t",
         "mac": "cmd+alt+t",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "1c-metadata-tree.revealActiveFileInTree",
+        "key": "ctrl+alt+t",
+        "mac": "cmd+alt+t",
+        "when": "activeWebviewPanelId == '1c-form-editor'"
       }
     ],
     "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.47.4",
+  "version": "0.47.5",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.47.3",
+  "version": "0.47.4",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/src/commands/navigationCommands.ts
+++ b/src/commands/navigationCommands.ts
@@ -156,12 +156,13 @@ export function registerNavigationCommands(
   const revealActiveFileCommand = vscode.commands.registerCommand(
     '1c-metadata-tree.revealActiveFileInTree',
     async () => {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
+      const uri =
+        vscode.window.activeTextEditor?.document.uri ??
+        state.formEditorProvider?.getActiveDocumentUri();
+      if (!uri) {
         vscode.window.showInformationMessage(MESSAGES.REVEAL_NO_ACTIVE_EDITOR);
         return;
       }
-      const uri = editor.document.uri;
       if (uri.scheme !== 'file') {
         vscode.window.showInformationMessage(MESSAGES.REVEAL_NOT_FILE_URI);
         return;

--- a/src/formEditor/formEditorProvider.ts
+++ b/src/formEditor/formEditorProvider.ts
@@ -34,6 +34,7 @@ export class FormEditorProvider implements vscode.CustomReadonlyEditorProvider<F
   private dirtyDocuments = new Set<string>();
   private contextByDocument = new Map<string, MessageHandlerContext>();
   private activeSelectionDocumentUri: string | null = null;
+  private activeDocumentUri: vscode.Uri | null = null;
   private latestSelectionByDocument = new Map<
     string,
     {
@@ -85,6 +86,16 @@ export class FormEditorProvider implements vscode.CustomReadonlyEditorProvider<F
     };
     const docKey = document.uri.toString();
     this.contextByDocument.set(docKey, ctx);
+    if (webviewPanel.active) {
+      this.activeDocumentUri = document.uri;
+    }
+    webviewPanel.onDidChangeViewState((event) => {
+      if (event.webviewPanel.active) {
+        this.activeDocumentUri = document.uri;
+      } else if (this.activeDocumentUri?.toString() === docKey) {
+        this.activeDocumentUri = null;
+      }
+    });
     const onMessage = createSerializedMessageHandler(ctx);
     webviewPanel.webview.onDidReceiveMessage(onMessage);
     webviewPanel.onDidDispose(() => {
@@ -104,6 +115,9 @@ export class FormEditorProvider implements vscode.CustomReadonlyEditorProvider<F
     if (this.activeSelectionDocumentUri === key) {
       this.activeSelectionDocumentUri = null;
     }
+    if (this.activeDocumentUri?.toString() === key) {
+      this.activeDocumentUri = null;
+    }
     if (!dirty) {
       return;
     }
@@ -118,6 +132,10 @@ export class FormEditorProvider implements vscode.CustomReadonlyEditorProvider<F
     if (choice === returnLabel) {
       await vscode.commands.executeCommand('vscode.openWith', documentUri, '1c-form-editor', { preview: false });
     }
+  }
+
+  public getActiveDocumentUri(): vscode.Uri | null {
+    return this.activeDocumentUri;
   }
 
   public gotoEventHandler(payload: { docUri: string; handlerName: string }): void {

--- a/test/fixtures/designer-config/Documents/TestDocument1/Forms/DocumentMainForm/DocumentMainForm.xml
+++ b/test/fixtures/designer-config/Documents/TestDocument1/Forms/DocumentMainForm/DocumentMainForm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<Form uuid="0ce7f0ed-f0c1-41ec-b9df-000000000096">
+		<Properties>
+			<Name>DocumentMainForm</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>Document Main Form</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+		</Properties>
+	</Form>
+</MetaDataObject>

--- a/test/fixtures/designer-config/Documents/TestDocument1/Forms/DocumentMainForm/Ext/Form.xml
+++ b/test/fixtures/designer-config/Documents/TestDocument1/Forms/DocumentMainForm/Ext/Form.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" version="2.20">
+	<ChildItems/>
+	<Attributes/>
+	<Commands/>
+</Form>

--- a/test/suite/smoke/revealActiveFile.smoke.test.ts
+++ b/test/suite/smoke/revealActiveFile.smoke.test.ts
@@ -225,6 +225,57 @@ suite('Smoke: revealActiveFileInTree command', () => {
     }
   });
 
+  test('smoke: revealActiveFileInTree - document form custom editor reveals Form node', async function () {
+    this.timeout(30000);
+
+    const formXmlPath = path.join(
+      workspacePath,
+      'Documents',
+      'TestDocument1',
+      'Forms',
+      'DocumentMainForm',
+      'Ext',
+      'Form.xml'
+    );
+
+    if (!fs.existsSync(formXmlPath)) {
+      recordFailure({
+        step: 'revealActiveFile:documentForm:precondition',
+        error: new Error('Fixture file not found: ' + formXmlPath),
+        command: '1c-metadata-tree.revealActiveFileInTree',
+      });
+      assert.fail('Fixture file not found: ' + formXmlPath);
+    }
+
+    try {
+      await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(formXmlPath), '1c-form-editor', {
+        preview: false,
+      });
+      await new Promise((r) => setTimeout(r, 1000));
+
+      await vscode.commands.executeCommand('1c-metadata-tree.revealActiveFileInTree');
+      await new Promise((r) => setTimeout(r, 1500));
+
+      const selectedName = await vscode.commands.executeCommand<string | null>(
+        '1c-metadata-tree.getSelectionNameForTest'
+      );
+      assert.strictEqual(
+        selectedName,
+        'DocumentMainForm',
+        'Selected node should be DocumentMainForm but got: ' + selectedName
+      );
+    } catch (err) {
+      recordFailure({
+        step: 'revealActiveFile:documentForm',
+        error: err instanceof Error ? err : new Error(String(err)),
+        command: '1c-metadata-tree.revealActiveFileInTree',
+      });
+      throw err;
+    } finally {
+      await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    }
+  });
+
   // TODO(#88): This test is a no-throw check only because VS Code does not expose
   // an API to intercept showInformationMessage() calls from tests, so we cannot
   // assert the info message text. The primary assertion is that the command


### PR DESCRIPTION
## Summary
- Fix `revealActiveFileInTree` for active `1c-form-editor` custom editor tabs.
- Add `Ctrl+Alt+T` keybinding support for the active form webview context.
- Bump extension version to 0.47.5 and add the VSIX built with the form reveal fix.

Fixes #96

## Test Plan
- `npm run compile`
- `test-suite.bat`
- `npm run test:smoke`
- Verified `releases/1c-metadata-tree-vscode-0.47.5.vsix` contains package version 0.47.5 and compiled `getActiveDocumentUri` fallback.