### PR TITLE
Speed up configuration discovery and lazy metadata loads

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.48.7",
+  "version": "0.48.8",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/src/commands/utilityCommands.ts
+++ b/src/commands/utilityCommands.ts
@@ -5,6 +5,7 @@ import { TreeNode } from '../models/treeNode';
 import { MESSAGES } from '../constants/messages';
 import { Logger } from '../utils/logger';
 import { clearTreeCache } from '../utils/diskCache';
+import { MetadataParser } from '../parsers/metadataParser';
 import { FormatDetector } from '../parsers/formatDetector';
 import { getSelectedNode } from '../helpers/commandHelpers';
 import { buildDiagnosticsSummaryText } from '../utils/diagnosticsSummary';
@@ -170,6 +171,7 @@ export function registerUtilityCommandsTrailing(deps: RegisterUtilityCommandsDep
     async () => {
       if (state.extensionContext?.globalStoragePath) {
         await clearTreeCache(state.extensionContext.globalStoragePath);
+        await MetadataParser.clearTypeContentsCache();
         vscode.window.showInformationMessage('CDT 41: cache cleared.');
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { ExtensionState } from './state/extensionState';
 import { createMetadataTreeLifecycle } from './extension/metadataTreeLifecycle';
 import { registerExtensionWorkspace } from './extension/extensionWorkspaceSetup';
 import { registerDebugAdapter } from './debug';
+import { MetadataParser } from './parsers/metadataParser';
 
 const extensionState = new ExtensionState();
 
@@ -15,6 +16,7 @@ const extensionState = new ExtensionState();
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   try {
     extensionState.init(context);
+    MetadataParser.setTypeContentsCacheStoragePath(context.globalStoragePath);
     initDesignerTemplateRepository(context.extensionPath);
     Logger.initialize();
     Logger.info(MESSAGES.EXTENSION_ACTIVATED);

--- a/src/extension/metadataTreeLifecycle.ts
+++ b/src/extension/metadataTreeLifecycle.ts
@@ -41,6 +41,7 @@ export function createMetadataTreeLifecycle(state: ExtensionState): MetadataTree
     if (state.extensionContext?.globalStoragePath) {
       await invalidateTreeCache(state.extensionContext.globalStoragePath, configPath);
     }
+    await MetadataParser.invalidateTypeContentsCache(configPath);
   }
 
   async function invalidateCacheAndReload(configPath: string): Promise<void> {
@@ -54,7 +55,6 @@ export function createMetadataTreeLifecycle(state: ExtensionState): MetadataTree
   });
 
   let loadInProgress: Promise<void> | null = null;
-
   async function doLoadMetadataTree(): Promise<void> {
     if (!state.treeDataProvider) {
       Logger.error(MESSAGES.ERROR_PROVIDER_NOT_INITIALIZED);
@@ -124,6 +124,7 @@ export function createMetadataTreeLifecycle(state: ExtensionState): MetadataTree
           } else {
             provider.setRootNodes(roots, loadContextMap);
           }
+          provider.startTypeContentsCacheWarmup();
 
           for (const w of state.metadataWatchers) {
             w.dispose();

--- a/src/parsers/formatDetector.ts
+++ b/src/parsers/formatDetector.ts
@@ -16,6 +16,14 @@ export enum ConfigFormat {
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
+const SKIPPED_DISCOVERY_DIRS = new Set(['node_modules', '.git', '.vscode', 'dist', 'out']);
+const CONFIG_ROOT_MARKERS = new Set(['1cv8.cf', '1cv8.cfe', CONFIGURATION_XML, 'ConfigDumpInfo.xml']);
+const NESTED_CONFIGURATION_CONTAINERS = [
+  ['ConfigurationExtensions'],
+  ['Extensions'],
+  ['src', 'Extensions'],
+] as const;
+
 /**
  * Detector for 1C configuration format
  */
@@ -61,27 +69,46 @@ export class FormatDetector {
    * Check if the given directory path is a configuration root (has 1cv8.cf, 1cv8.cfe, or valid Configuration.xml).
    */
   private static async isConfigurationRoot(dirPath: string): Promise<boolean> {
-    const cfPath = path.join(dirPath, '1cv8.cf');
-    const cfePath = path.join(dirPath, '1cv8.cfe');
-    const configXmlPath = path.join(dirPath, CONFIGURATION_XML);
+    const entries = await this.readDirectoryEntries(dirPath);
+    return entries ? this.hasConfigurationRootMarkers(entries) : false;
+  }
+
+  private static async readDirectoryEntries(dirPath: string): Promise<fs.Dirent[] | null> {
     try {
-      await fs.promises.access(cfPath);
-      return true;
-    } catch {
-      // continue
+      return await fs.promises.readdir(dirPath, { withFileTypes: true });
+    } catch (error) {
+      Logger.debug(`Error reading directory ${dirPath}`, error);
+      return null;
     }
-    try {
-      await fs.promises.access(cfePath);
-      return true;
-    } catch {
-      // continue
+  }
+
+  private static hasConfigurationRootMarkers(entries: readonly fs.Dirent[]): boolean {
+    const names = new Set(entries.filter((entry) => entry.isFile()).map((entry) => entry.name));
+    return [...CONFIG_ROOT_MARKERS].some((marker) => names.has(marker));
+  }
+
+  private static getCandidateChildDirectories(dirPath: string, entries: readonly fs.Dirent[]): string[] {
+    return entries
+      .filter((entry) => entry.isDirectory() && !SKIPPED_DISCOVERY_DIRS.has(entry.name))
+      .map((entry) => path.join(dirPath, entry.name));
+  }
+
+  private static async findNestedKnownConfigurationRoots(configRootPath: string): Promise<string[]> {
+    const found: string[] = [];
+    for (const containerSegments of NESTED_CONFIGURATION_CONTAINERS) {
+      const containerPath = path.join(configRootPath, ...containerSegments);
+      const entries = await this.readDirectoryEntries(containerPath);
+      if (!entries) {
+        continue;
+      }
+      for (const childPath of this.getCandidateChildDirectories(containerPath, entries)) {
+        const childEntries = await this.readDirectoryEntries(childPath);
+        if (childEntries && this.hasConfigurationRootMarkers(childEntries)) {
+          found.push(childPath);
+        }
+      }
     }
-    try {
-      await fs.promises.access(configXmlPath);
-      return true;
-    } catch {
-      return false;
-    }
+    return found;
   }
 
   /**
@@ -123,6 +150,15 @@ export class FormatDetector {
             seen.add(n);
             result.push({ configPath: workspacePath, workspaceFolderPath: workspacePath });
           }
+          const nested = await this.findNestedKnownConfigurationRoots(workspacePath);
+          for (const configPath of nested) {
+            const n = normalize(configPath);
+            if (!seen.has(n)) {
+              seen.add(n);
+              result.push({ configPath, workspaceFolderPath: workspacePath });
+            }
+          }
+          continue;
         }
         const inSubdirs = await this.searchAllConfigurationsRecursive(workspacePath, 0, 5);
         for (const configPath of inSubdirs) {
@@ -145,32 +181,39 @@ export class FormatDetector {
   private static async searchAllConfigurationsRecursive(
     dirPath: string,
     currentDepth: number,
-    maxDepth: number
+    maxDepth: number,
+    knownEntries?: fs.Dirent[]
   ): Promise<string[]> {
     if (currentDepth >= maxDepth) {return [];}
     const found: string[] = [];
-    try {
-      const items = await fs.promises.readdir(dirPath);
-      for (const item of items) {
-        if (item === 'node_modules' || item === '.git' || item === '.vscode' || item === 'dist' || item === 'out') {
-          continue;
-        }
-        const itemPath = path.join(dirPath, item);
-        try {
-          const stat = await fs.promises.stat(itemPath);
-          if (!stat.isDirectory()) {continue;}
-          if (await this.isConfigurationRoot(itemPath)) {
-            found.push(itemPath);
-            Logger.info(`Found configuration at depth ${currentDepth + 1}: ${itemPath}`);
-          }
-          const sub = await this.searchAllConfigurationsRecursive(itemPath, currentDepth + 1, maxDepth);
-          found.push(...sub);
-        } catch (error) {
-          Logger.debug(`Error checking subdirectory ${itemPath}`, error);
-        }
+    const entries = knownEntries ?? await this.readDirectoryEntries(dirPath);
+    if (!entries) {
+      return found;
+    }
+
+    const nonRootChildren: Array<{ itemPath: string; entries: fs.Dirent[] }> = [];
+    for (const itemPath of this.getCandidateChildDirectories(dirPath, entries)) {
+      const childEntries = await this.readDirectoryEntries(itemPath);
+      if (!childEntries) {
+        continue;
       }
-    } catch (error) {
-      Logger.debug(`Error reading directory ${dirPath}`, error);
+      if (this.hasConfigurationRootMarkers(childEntries)) {
+        found.push(itemPath);
+        Logger.info(`Found configuration at depth ${currentDepth + 1}: ${itemPath}`);
+        found.push(...await this.findNestedKnownConfigurationRoots(itemPath));
+        continue;
+      }
+      nonRootChildren.push({ itemPath, entries: childEntries });
+    }
+
+    for (const child of nonRootChildren) {
+      const sub = await this.searchAllConfigurationsRecursive(
+        child.itemPath,
+        currentDepth + 1,
+        maxDepth,
+        child.entries
+      );
+      found.push(...sub);
     }
     return found;
   }
@@ -185,59 +228,43 @@ export class FormatDetector {
   private static async searchConfigurationRecursive(
     dirPath: string,
     currentDepth: number,
-    maxDepth: number
+    maxDepth: number,
+    knownEntries?: fs.Dirent[]
   ): Promise<string | null> {
     if (currentDepth >= maxDepth) {
       return null;
     }
 
-    try {
-      const items = await fs.promises.readdir(dirPath);
-
-      for (const item of items) {
-        // Skip common non-config directories
-        if (item === 'node_modules' || item === '.git' || item === '.vscode' || item === 'dist' || item === 'out') {
-          continue;
-        }
-
-        const itemPath = path.join(dirPath, item);
-        try {
-          const stat = await fs.promises.stat(itemPath);
-
-          if (stat.isDirectory()) {
-            // Check if this directory is a configuration root
-            const cfPath = path.join(itemPath, '1cv8.cf');
-            const cfePath = path.join(itemPath, '1cv8.cfe');
-            const configXmlPath = path.join(itemPath, CONFIGURATION_XML);
-
-            // Check all paths in parallel
-            const checks = await Promise.allSettled([
-              fs.promises.access(cfPath),
-              fs.promises.access(cfePath),
-              fs.promises.access(configXmlPath),
-            ]);
-
-            if (checks.some(result => result.status === 'fulfilled')) {
-              Logger.info(`Found configuration at depth ${currentDepth + 1}: ${itemPath}`);
-              return itemPath;
-            }
-
-            // Recursively search in this subdirectory
-            const found = await this.searchConfigurationRecursive(itemPath, currentDepth + 1, maxDepth);
-            if (found) {
-              return found;
-            }
-          }
-        } catch (error) {
-          Logger.debug(`Error checking subdirectory ${itemPath}`, error);
-        }
-      }
-
-      return null;
-    } catch (error) {
-      Logger.debug(`Error reading directory ${dirPath}`, error);
+    const entries = knownEntries ?? await this.readDirectoryEntries(dirPath);
+    if (!entries) {
       return null;
     }
+
+    const nonRootChildren: Array<{ itemPath: string; entries: fs.Dirent[] }> = [];
+    for (const itemPath of this.getCandidateChildDirectories(dirPath, entries)) {
+      const childEntries = await this.readDirectoryEntries(itemPath);
+      if (!childEntries) {
+        continue;
+      }
+      if (this.hasConfigurationRootMarkers(childEntries)) {
+        Logger.info(`Found configuration at depth ${currentDepth + 1}: ${itemPath}`);
+        return itemPath;
+      }
+      nonRootChildren.push({ itemPath, entries: childEntries });
+    }
+
+    for (const child of nonRootChildren) {
+      const found = await this.searchConfigurationRecursive(
+        child.itemPath,
+        currentDepth + 1,
+        maxDepth,
+        child.entries
+      );
+      if (found) {
+        return found;
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/parsers/metadataParser.ts
+++ b/src/parsers/metadataParser.ts
@@ -1,8 +1,16 @@
+import * as path from 'path';
 import { TreeNode, MetadataType } from '../models/treeNode';
 import { Logger } from '../utils/logger';
 import { DesignerParser } from './designerParser';
 import { EdtParser } from './edtParser';
 import { FormatDetector, ConfigFormat } from './formatDetector';
+import {
+  clearTypeContentsCache,
+  computeTypeContentsSignature,
+  invalidateTypeContentsCache,
+  loadTypeContentsFromCache,
+  saveTypeContentsToCache,
+} from '../utils/typeContentsCache';
 import {
   ensureTabularSectionColumnsPlaceholder,
   isTabularSectionColumnsContainer,
@@ -35,6 +43,50 @@ const R6_OBJECT_TYPES = new Set<MetadataType>([
  * Main metadata parser that handles both EDT and Designer formats
  */
 export class MetadataParser {
+  private static typeContentsCacheStoragePath: string | null = null;
+
+  static setTypeContentsCacheStoragePath(storagePath: string | null): void {
+    this.typeContentsCacheStoragePath = storagePath && storagePath.trim() ? storagePath : null;
+  }
+
+  static async invalidateTypeContentsCache(configPath: string): Promise<void> {
+    if (!this.typeContentsCacheStoragePath) {
+      return;
+    }
+    await invalidateTypeContentsCache(this.typeContentsCacheStoragePath, configPath);
+  }
+
+  static async clearTypeContentsCache(): Promise<void> {
+    if (!this.typeContentsCacheStoragePath) {
+      return;
+    }
+    await clearTypeContentsCache(this.typeContentsCacheStoragePath);
+  }
+
+  private static getTypePath(configPath: string, typeName: string, format: ConfigFormat): string | null {
+    if (format === ConfigFormat.Designer) {
+      return path.join(configPath, typeName);
+    }
+    if (format === ConfigFormat.EDT) {
+      return path.join(configPath, 'src', typeName);
+    }
+    return null;
+  }
+
+  private static async parseTypeContentsUncached(
+    configPath: string,
+    typeName: string,
+    format: ConfigFormat
+  ): Promise<TreeNode[]> {
+    if (format === ConfigFormat.Designer) {
+      return await DesignerParser.parseTypeContents(configPath, typeName);
+    }
+    if (format === ConfigFormat.EDT) {
+      return await EdtParser.parseTypeContents(configPath, typeName);
+    }
+    return [];
+  }
+
   /**
    * Build only root and type nodes without loading element contents (for lazy loading).
    * @param configPath Path to configuration root directory
@@ -60,15 +112,31 @@ export class MetadataParser {
    * @param typeName Type directory name (e.g. Catalogs)
    * @returns Array of element tree nodes for this type
    */
-  static async parseTypeContents(configPath: string, typeName: string): Promise<TreeNode[]> {
-    const format = await FormatDetector.detect(configPath);
-    if (format === ConfigFormat.Designer) {
-      return await DesignerParser.parseTypeContents(configPath, typeName);
+  static async parseTypeContents(
+    configPath: string,
+    typeName: string,
+    options?: { format?: ConfigFormat; bypassCache?: boolean }
+  ): Promise<TreeNode[]> {
+    const format = options?.format ?? await FormatDetector.detect(configPath);
+    const typePath = this.getTypePath(configPath, typeName, format);
+    const storagePath = this.typeContentsCacheStoragePath;
+    if (!typePath || options?.bypassCache === true || !storagePath) {
+      return await this.parseTypeContentsUncached(configPath, typeName, format);
     }
-    if (format === ConfigFormat.EDT) {
-      return await EdtParser.parseTypeContents(configPath, typeName);
+
+    const signature = await computeTypeContentsSignature(typePath, format);
+    if (!signature) {
+      return await this.parseTypeContentsUncached(configPath, typeName, format);
     }
-    return [];
+
+    const cached = await loadTypeContentsFromCache(storagePath, configPath, typeName, signature);
+    if (cached) {
+      return cached;
+    }
+
+    const children = await this.parseTypeContentsUncached(configPath, typeName, format);
+    await saveTypeContentsToCache(storagePath, configPath, typeName, signature, children);
+    return children;
   }
 
   /**

--- a/src/providers/objectTypeLoader.ts
+++ b/src/providers/objectTypeLoader.ts
@@ -3,6 +3,7 @@ import { TreeNode } from '../models/treeNode';
 import { Logger } from '../utils/logger';
 import type { ObjectableGroup } from '../types/objectTypeDefinitions';
 import { MetadataParser } from '../parsers/metadataParser';
+import { ConfigFormat } from '../parsers/formatDetector';
 import { METADATA_TYPE_TO_OBJECT_KIND, OBJECT_KIND_ORDER, ALL_MANAGER_KINDS } from '../constants/metadataTypeObjectKinds';
 import { resolveRootsToUse } from './treeReferenceLoader';
 import { TreeCacheService } from './treeCacheService';
@@ -79,7 +80,7 @@ export async function getObjectableObjectsForEditor(
     }));
   }
 
-  type LoadTask = { typeNode: TreeNode; configPath: string };
+  type LoadTask = { typeNode: TreeNode; configPath: string; format?: ConfigFormat };
   const loadTasks: LoadTask[] = [];
 
   for (const root of rootsToUse) {
@@ -87,8 +88,8 @@ export async function getObjectableObjectsForEditor(
       continue;
     }
 
-    const configPath =
-      cache.getLoadContext(root.id)?.configPath ?? (root.filePath ? path.dirname(root.filePath) : null);
+    const loadContext = cache.getLoadContext(root.id);
+    const configPath = loadContext?.configPath ?? (root.filePath ? path.dirname(root.filePath) : null);
 
     if (!configPath) {
       continue;
@@ -101,15 +102,15 @@ export async function getObjectableObjectsForEditor(
       if (typeNode.children && typeNode.children.length > 0) {
         continue;
       }
-      loadTasks.push({ typeNode, configPath });
+      loadTasks.push({ typeNode, configPath, format: loadContext?.format });
     }
   }
 
   if (loadTasks.length > 0) {
     const settled = await Promise.all(
-      loadTasks.map(async ({ typeNode, configPath }) => {
+      loadTasks.map(async ({ typeNode, configPath, format }) => {
         try {
-          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id);
+          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id, { format });
           return { typeNode, children };
         } catch (e) {
           Logger.warn('Failed to eager load objectable type contents for object type editor', {

--- a/src/providers/treeDataProvider.ts
+++ b/src/providers/treeDataProvider.ts
@@ -40,6 +40,18 @@ import type { MetadataLocation } from '../services/metadataFileLocator';
 
 /** R6 placeholders under object XML — reload via loadElementChildren after mutations (see invalidateLoadedChildren). */
 const R6_LAZY_SECTION_IDS = new Set(['Attributes', 'TabularSections', 'Forms', 'Commands', 'Templates', 'Dimensions', 'Resources', 'EnumValues', 'PredefinedData']);
+const TYPE_CONTENTS_WARMUP_PRIORITY = new Map<string, number>([
+  ['Catalogs', 0],
+  ['Documents', 1],
+  ['Enums', 2],
+  ['CommonModules', 3],
+  ['InformationRegisters', 4],
+  ['Reports', 5],
+  ['DataProcessors', 6],
+  ['Roles', 7],
+  ['Constants', 8],
+  ['CommonPictures', 9],
+]);
 
 /**
  * Tree Data Provider for VS Code Tree View
@@ -58,6 +70,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
   private readonly typeEditorReferenceableCache = new Map<string, ReferenceableGroup[]>();
   /** Snapshot of objectable object groups per scope for ObjectTypeEditor (invalidated with tree reload / structure). */
   private readonly objectableObjectsCache = new Map<string, ObjectableGroup[]>();
+  private typeContentsWarmupGeneration = 0;
 
   private messageUpdater: ((message: string | undefined) => void) | null = null;
   /** Ключ {@link bindingKey}(workspaceFolder, configRelativePath) → сводка для узла Configuration. */
@@ -336,7 +349,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
         Logger.info('Eager loading type for subsystem filter', { folder });
         try {
-          const children = await MetadataParser.parseTypeContents(ctx.configPath, folder);
+          const children = await MetadataParser.parseTypeContents(ctx.configPath, folder, { format: ctx.format });
           for (const c of children) {
             c.parent = typeNode;
             this.cache.buildCache(c);
@@ -552,7 +565,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
       if (!this.isLazyTypeNode(typeFolder)) { continue; }
 
       try {
-        const children = await MetadataParser.parseTypeContents(ctx.configPath, typeFolder.id);
+        const children = await MetadataParser.parseTypeContents(ctx.configPath, typeFolder.id, { format: ctx.format });
         for (const c of children) {
           c.parent = typeFolder;
           this.cache.buildCache(c);
@@ -563,6 +576,70 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
       }
     }
     this.clearTypeEditorReferenceableCache();
+  }
+
+  startTypeContentsCacheWarmup(delayMs = 1000): void {
+    const generation = ++this.typeContentsWarmupGeneration;
+    const roots = [...this.rootNodes];
+    if (roots.length === 0) {
+      return;
+    }
+    setTimeout(() => {
+      void this.warmUpTypeContentsCache(roots, generation).catch((error) => {
+        Logger.warn('Type contents cache warmup failed', error);
+      });
+    }, delayMs);
+  }
+
+  private collectWarmupTypeFolders(root: TreeNode): TreeNode[] {
+    const folders: TreeNode[] = [];
+    for (const child of root.children ?? []) {
+      if (this.isLazyTypeNode(child)) {
+        folders.push(child);
+      }
+      if (child.id === 'Common') {
+        for (const commonChild of child.children ?? []) {
+          if (this.isLazyTypeNode(commonChild)) {
+            folders.push(commonChild);
+          }
+        }
+      }
+    }
+    return folders.sort((a, b) => {
+      const pa = TYPE_CONTENTS_WARMUP_PRIORITY.get(a.id) ?? 1000;
+      const pb = TYPE_CONTENTS_WARMUP_PRIORITY.get(b.id) ?? 1000;
+      if (pa !== pb) {
+        return pa - pb;
+      }
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  private async warmUpTypeContentsCache(roots: TreeNode[], generation: number): Promise<void> {
+    for (const root of roots) {
+      if (generation !== this.typeContentsWarmupGeneration) {
+        return;
+      }
+      const ctx = this.cache.getLoadContext(root.id);
+      if (!ctx) {
+        continue;
+      }
+      for (const typeFolder of this.collectWarmupTypeFolders(root)) {
+        if (generation !== this.typeContentsWarmupGeneration) {
+          return;
+        }
+        if (typeFolder.children && typeFolder.children.length > 0) {
+          continue;
+        }
+        const startedAt = Date.now();
+        await MetadataParser.parseTypeContents(ctx.configPath, typeFolder.id, { format: ctx.format });
+        const durationMs = Date.now() - startedAt;
+        if (durationMs >= 1000) {
+          Logger.info('Type contents cache warmup item completed', { typeName: typeFolder.id, durationMs });
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    }
   }
 
   /**
@@ -768,7 +845,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
         const configRoot = this.cache.getConfigurationRoot(activeElement);
         const ctx = configRoot ? this.cache.getLoadContext(configRoot.id) : undefined;
         if (!ctx) {return Promise.resolve([]);}
-        return MetadataParser.parseTypeContents(ctx.configPath, activeElement.id).then((children) => {
+        return MetadataParser.parseTypeContents(ctx.configPath, activeElement.id, { format: ctx.format }).then((children) => {
           for (const c of children) {
             c.parent = activeElement;
             this.cache.buildCache(c);

--- a/src/providers/treeReferenceLoader.ts
+++ b/src/providers/treeReferenceLoader.ts
@@ -3,6 +3,7 @@ import { TreeNode, MetadataType } from '../models/treeNode';
 import { Logger } from '../utils/logger';
 import type { ReferenceableGroup } from '../types/typeDefinitions';
 import { MetadataParser } from '../parsers/metadataParser';
+import { ConfigFormat } from '../parsers/formatDetector';
 import { METADATA_TYPE_TO_REFERENCE_KIND } from '../constants/metadataTypeReferenceKinds';
 import { TreeCacheService } from './treeCacheService';
 
@@ -191,7 +192,7 @@ export async function getReferenceableObjectsForTypeEditor(
     return [];
   }
 
-  type LoadTask = { typeNode: TreeNode; configPath: string };
+  type LoadTask = { typeNode: TreeNode; configPath: string; format?: ConfigFormat };
   const loadTasks: LoadTask[] = [];
 
   for (const root of rootsToUse) {
@@ -199,8 +200,8 @@ export async function getReferenceableObjectsForTypeEditor(
       continue;
     }
 
-    const configPath =
-      cache.getLoadContext(root.id)?.configPath ?? (root.filePath ? path.dirname(root.filePath) : null);
+    const loadContext = cache.getLoadContext(root.id);
+    const configPath = loadContext?.configPath ?? (root.filePath ? path.dirname(root.filePath) : null);
 
     if (!configPath) {
       continue;
@@ -213,15 +214,15 @@ export async function getReferenceableObjectsForTypeEditor(
       if (typeNode.children && typeNode.children.length > 0) {
         continue;
       }
-      loadTasks.push({ typeNode, configPath });
+      loadTasks.push({ typeNode, configPath, format: loadContext?.format });
     }
   }
 
   if (loadTasks.length > 0) {
     const settled = await Promise.all(
-      loadTasks.map(async ({ typeNode, configPath }) => {
+      loadTasks.map(async ({ typeNode, configPath, format }) => {
         try {
-          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id);
+          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id, { format });
           return { typeNode, children };
         } catch (e) {
           Logger.warn('Failed to eager load referenceable type contents for type editor', {

--- a/src/rolesEditor/metadataLoader.ts
+++ b/src/rolesEditor/metadataLoader.ts
@@ -200,7 +200,7 @@ export async function loadMetadataObjects(
         }
 
         // Load elements for this type
-        const elements = await MetadataParser.parseTypeContents(effectiveConfigPath, typeNode.name);
+        const elements = await MetadataParser.parseTypeContents(effectiveConfigPath, typeNode.name, { format });
 
         for (const element of elements) {
           const metadataObject = createMetadataObject(element, currentRights);

--- a/src/utils/typeContentsCache.ts
+++ b/src/utils/typeContentsCache.ts
@@ -1,0 +1,191 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ConfigFormat } from '../parsers/formatDetector';
+import { TreeNode, MetadataType } from '../models/treeNode';
+import { deserializeTree, serializeTree } from './treeSerializer';
+import { Logger } from './logger';
+
+interface TypeContentsCacheEntry {
+  configPath: string;
+  typeName: string;
+  signature: string;
+  tree: string;
+  version: string;
+}
+
+const CACHE_VERSION = '1.0';
+
+function hash(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function getCacheDir(globalStoragePath: string): string {
+  return path.join(globalStoragePath, '1cviewer-type-contents-cache');
+}
+
+function getConfigCachePrefix(configPath: string): string {
+  return `${hash(path.normalize(configPath))}-`;
+}
+
+function getCacheFilePath(globalStoragePath: string, configPath: string, typeName: string): string {
+  return path.join(getCacheDir(globalStoragePath), `${getConfigCachePrefix(configPath)}${hash(typeName)}.json`);
+}
+
+function normalizePathForSignature(value: string): string {
+  return path.normalize(value).replace(/\\/g, '/').toLowerCase();
+}
+
+async function statPart(filePath: string, label: string): Promise<string | null> {
+  const st = await fs.promises.stat(filePath).catch(() => null);
+  if (!st) {
+    return null;
+  }
+  return `${label}:${st.isDirectory() ? 'd' : 'f'}:${Math.round(st.mtimeMs)}:${st.size}`;
+}
+
+async function collectEdtElementMetadataParts(elementPath: string, elementName: string): Promise<string[]> {
+  const parts: string[] = [];
+  const entries = await fs.promises.readdir(elementPath, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const lower = entry.name.toLowerCase();
+    if (!lower.endsWith('.mdo') && !lower.endsWith('.xml')) {
+      continue;
+    }
+    const part = await statPart(path.join(elementPath, entry.name), `${elementName}/${entry.name}`);
+    if (part) {
+      parts.push(part);
+    }
+  }
+  return parts;
+}
+
+/**
+ * Lightweight freshness signature for a type folder.
+ *
+ * Full recursive stat over large configurations is close to reparsing cost, so this tracks:
+ * - direct type folder entries;
+ * - Designer sibling XML files (direct entries);
+ * - EDT immediate .mdo/.xml files inside each object directory.
+ *
+ * Open-session edits are additionally handled by watcher-driven invalidation.
+ */
+export async function computeTypeContentsSignature(
+  typePath: string,
+  format: ConfigFormat
+): Promise<string | null> {
+  const entries = await fs.promises.readdir(typePath, { withFileTypes: true }).catch(() => null);
+  if (!entries) {
+    return null;
+  }
+
+  const parts: string[] = [`path:${normalizePathForSignature(typePath)}`, `format:${format}`];
+  const sortedEntries = [...entries].sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of sortedEntries) {
+    const entryPath = path.join(typePath, entry.name);
+    const part = await statPart(entryPath, entry.name);
+    if (part) {
+      parts.push(part);
+    }
+    if (format === ConfigFormat.EDT && entry.isDirectory()) {
+      parts.push(...await collectEdtElementMetadataParts(entryPath, entry.name));
+    }
+  }
+
+  return crypto.createHash('sha256').update(parts.join('|')).digest('hex');
+}
+
+export async function loadTypeContentsFromCache(
+  globalStoragePath: string,
+  configPath: string,
+  typeName: string,
+  signature: string
+): Promise<TreeNode[] | null> {
+  try {
+    const cacheFilePath = getCacheFilePath(globalStoragePath, configPath, typeName);
+    const raw = await fs.promises.readFile(cacheFilePath, 'utf-8');
+    const entry = JSON.parse(raw) as TypeContentsCacheEntry;
+    if (
+      entry.version !== CACHE_VERSION ||
+      entry.configPath !== configPath ||
+      entry.typeName !== typeName ||
+      entry.signature !== signature ||
+      !entry.tree
+    ) {
+      return null;
+    }
+
+    const root = deserializeTree(entry.tree);
+    const children = root.children ?? [];
+    for (const child of children) {
+      child.parent = undefined;
+    }
+    Logger.debug('Type contents loaded from disk cache', { typeName, count: children.length });
+    return children;
+  } catch (error) {
+    Logger.debug('Failed to load type contents cache', error);
+    return null;
+  }
+}
+
+export async function saveTypeContentsToCache(
+  globalStoragePath: string,
+  configPath: string,
+  typeName: string,
+  signature: string,
+  children: TreeNode[]
+): Promise<void> {
+  try {
+    const dir = getCacheDir(globalStoragePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    const root: TreeNode = {
+      id: `type-cache:${typeName}`,
+      name: typeName,
+      type: MetadataType.Unknown,
+      properties: {},
+      children,
+    };
+    const entry: TypeContentsCacheEntry = {
+      configPath,
+      typeName,
+      signature,
+      tree: serializeTree(root),
+      version: CACHE_VERSION,
+    };
+    await fs.promises.writeFile(
+      getCacheFilePath(globalStoragePath, configPath, typeName),
+      JSON.stringify(entry),
+      'utf-8'
+    );
+    Logger.debug('Type contents saved to disk cache', { typeName, count: children.length });
+  } catch (error) {
+    Logger.warn('Failed to save type contents cache', error);
+  }
+}
+
+export async function invalidateTypeContentsCache(
+  globalStoragePath: string,
+  configPath: string
+): Promise<void> {
+  const dir = getCacheDir(globalStoragePath);
+  const prefix = getConfigCachePrefix(configPath);
+  const files = await fs.promises.readdir(dir).catch(() => [] as string[]);
+  await Promise.all(
+    files
+      .filter((file) => file.startsWith(prefix) && file.endsWith('.json'))
+      .map((file) => fs.promises.unlink(path.join(dir, file)).catch(() => {}))
+  );
+}
+
+export async function clearTypeContentsCache(globalStoragePath: string): Promise<void> {
+  const dir = getCacheDir(globalStoragePath);
+  const files = await fs.promises.readdir(dir).catch(() => [] as string[]);
+  await Promise.all(
+    files
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => fs.promises.unlink(path.join(dir, file)).catch(() => {}))
+  );
+}

--- a/test/suite/coreSuiteRegistration.test.ts
+++ b/test/suite/coreSuiteRegistration.test.ts
@@ -31,6 +31,7 @@ const mustRegisterInCoreCi: readonly string[] = [
   'suite/xmlChildObjects.test.js',
   'suite/xmlPropertyUtils.test.js',
   'suite/metadataParser.edge.test.js',
+  'suite/typeContentsCache.test.js',
   'suite/errorHandling.test.js',
 ];
 

--- a/test/suite/coreSuites.ts
+++ b/test/suite/coreSuites.ts
@@ -8,6 +8,7 @@ export const coreSuiteFiles: string[] = [
   'suite/formXmlWriter.test.js',
   'suite/metadataParser.test.js',
   'suite/metadataParser.edge.test.js',
+  'suite/typeContentsCache.test.js',
   'suite/metadataDefaultValues.test.js',
   'suite/metadataFileLocator.test.js',
   'suite/metadataTypeMapper.test.js',

--- a/test/suite/formatDetector.test.ts
+++ b/test/suite/formatDetector.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { FormatDetector, ConfigFormat } from '../../src/parsers/formatDetector';
 
@@ -85,5 +87,24 @@ suite('FormatDetector', () => {
     const smallMatrix = result.find((r) => r.configPath.endsWith(path.join('matrix', 'small')));
     assert.ok(smallMatrix, 'expected matrix/small configuration root');
     assert.strictEqual(smallMatrix?.workspaceFolderPath, fixturesPath);
+  });
+
+  test('findAllConfigurationRoots does not recurse into discovered configuration roots', async () => {
+    const workspacePath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-fd-prune-'));
+    const configPath = path.join(workspacePath, 'big-config');
+    const nestedConfigPath = path.join(configPath, 'Catalogs', 'NestedLikeConfig');
+
+    await fs.promises.mkdir(nestedConfigPath, { recursive: true });
+    await fs.promises.writeFile(path.join(configPath, 'Configuration.xml'), '<Configuration/>', 'utf-8');
+    await fs.promises.writeFile(path.join(nestedConfigPath, 'Configuration.xml'), '<Configuration/>', 'utf-8');
+
+    const result = await FormatDetector.findAllConfigurationRoots([workspacePath]);
+    const configPaths = result.map((r) => path.normalize(r.configPath));
+
+    assert.ok(configPaths.includes(path.normalize(configPath)), 'top-level configuration should be discovered');
+    assert.ok(
+      !configPaths.includes(path.normalize(nestedConfigPath)),
+      'nested markers inside an already discovered configuration root must be ignored'
+    );
   });
 });

--- a/test/suite/metadataParser.edge.test.ts
+++ b/test/suite/metadataParser.edge.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { MetadataType, TreeNode } from '../../src/models/treeNode';
 import { MetadataParser } from '../../src/parsers/metadataParser';
 import { ConfigFormat, FormatDetector } from '../../src/parsers/formatDetector';
@@ -46,6 +49,61 @@ suite('MetadataParser edge branches', () => {
       (FormatDetector.detect as unknown as typeof FormatDetector.detect) = originalDetect;
       (DesignerParser.parseTypeContents as unknown as typeof DesignerParser.parseTypeContents) = originalDesigner;
       (EdtParser.parseTypeContents as unknown as typeof EdtParser.parseTypeContents) = originalEdt;
+    }
+  });
+
+  test('parseTypeContents uses provided format without detecting again', async () => {
+    const originalDetect = FormatDetector.detect;
+    const originalDesigner = DesignerParser.parseTypeContents;
+    try {
+      (FormatDetector.detect as unknown as (p: string) => Promise<ConfigFormat>) = async () => {
+        throw new Error('detect should not run');
+      };
+      (DesignerParser.parseTypeContents as unknown as (a: string, b: string) => Promise<TreeNode[]>) = async () => [
+        { id: 'cached-format', name: 'D', type: MetadataType.Catalog, properties: {} },
+      ];
+
+      const children = await MetadataParser.parseTypeContents('cfg', 'Catalogs', {
+        format: ConfigFormat.Designer,
+        bypassCache: true,
+      });
+
+      assert.strictEqual(children[0].id, 'cached-format');
+    } finally {
+      (FormatDetector.detect as unknown as typeof FormatDetector.detect) = originalDetect;
+      (DesignerParser.parseTypeContents as unknown as typeof DesignerParser.parseTypeContents) = originalDesigner;
+    }
+  });
+
+  test('parseTypeContents reuses disk cache for unchanged type folders', async () => {
+    const configPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-cache-cfg-'));
+    const storagePath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-cache-store-'));
+    await fs.promises.mkdir(path.join(configPath, 'Catalogs'), { recursive: true });
+    await fs.promises.writeFile(path.join(configPath, 'Catalogs', 'Goods.xml'), '<MetaDataObject/>', 'utf-8');
+
+    const originalDetect = FormatDetector.detect;
+    const originalDesigner = DesignerParser.parseTypeContents;
+    let parseCount = 0;
+    try {
+      MetadataParser.setTypeContentsCacheStoragePath(storagePath);
+      (FormatDetector.detect as unknown as (p: string) => Promise<ConfigFormat>) = async () => ConfigFormat.Designer;
+      (DesignerParser.parseTypeContents as unknown as (a: string, b: string) => Promise<TreeNode[]>) = async () => {
+        parseCount += 1;
+        return [{ id: 'Catalogs.Goods', name: 'Goods', type: MetadataType.Catalog, properties: {} }];
+      };
+
+      const first = await MetadataParser.parseTypeContents(configPath, 'Catalogs');
+      const second = await MetadataParser.parseTypeContents(configPath, 'Catalogs');
+
+      assert.strictEqual(first[0].id, 'Catalogs.Goods');
+      assert.strictEqual(second[0].id, 'Catalogs.Goods');
+      assert.strictEqual(parseCount, 1);
+    } finally {
+      MetadataParser.setTypeContentsCacheStoragePath(null);
+      (FormatDetector.detect as unknown as typeof FormatDetector.detect) = originalDetect;
+      (DesignerParser.parseTypeContents as unknown as typeof DesignerParser.parseTypeContents) = originalDesigner;
+      await fs.promises.rm(configPath, { recursive: true, force: true });
+      await fs.promises.rm(storagePath, { recursive: true, force: true });
     }
   });
 

--- a/test/suite/typeContentsCache.test.ts
+++ b/test/suite/typeContentsCache.test.ts
@@ -1,0 +1,105 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MetadataType, TreeNode } from '../../src/models/treeNode';
+import { ConfigFormat } from '../../src/parsers/formatDetector';
+import {
+  clearTypeContentsCache,
+  computeTypeContentsSignature,
+  invalidateTypeContentsCache,
+  loadTypeContentsFromCache,
+  saveTypeContentsToCache,
+} from '../../src/utils/typeContentsCache';
+
+suite('typeContentsCache', () => {
+  async function makeTempDir(prefix: string): Promise<string> {
+    return await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  }
+
+  test('computeTypeContentsSignature returns null for missing type folder', async () => {
+    const missing = path.join(os.tmpdir(), `1cviewer-missing-${Date.now()}`);
+    assert.strictEqual(await computeTypeContentsSignature(missing, ConfigFormat.Designer), null);
+  });
+
+  test('save and load round-trips children and restores nested parent links', async () => {
+    const configPath = await makeTempDir('1cviewer-type-cache-cfg-');
+    const storagePath = await makeTempDir('1cviewer-type-cache-store-');
+    const typePath = path.join(configPath, 'Catalogs');
+    await fs.promises.mkdir(typePath, { recursive: true });
+    await fs.promises.writeFile(path.join(typePath, 'Goods.xml'), '<MetaDataObject/>', 'utf-8');
+
+    const signature = await computeTypeContentsSignature(typePath, ConfigFormat.Designer);
+    assert.ok(signature);
+
+    const child: TreeNode = {
+      id: 'Catalogs.Goods',
+      name: 'Goods',
+      type: MetadataType.Catalog,
+      properties: { _lazy: true },
+      children: [
+        {
+          id: 'Catalogs.Goods.Ext',
+          name: 'Ext',
+          type: MetadataType.Extension,
+          properties: {},
+        },
+      ],
+    };
+    child.children![0].parent = child;
+
+    await saveTypeContentsToCache(storagePath, configPath, 'Catalogs', signature, [child]);
+    const loaded = await loadTypeContentsFromCache(storagePath, configPath, 'Catalogs', signature);
+
+    assert.ok(loaded);
+    assert.strictEqual(loaded.length, 1);
+    assert.strictEqual(loaded[0].id, 'Catalogs.Goods');
+    assert.strictEqual(loaded[0].parent, undefined);
+    assert.strictEqual(loaded[0].children?.[0].parent, loaded[0]);
+
+    await fs.promises.rm(configPath, { recursive: true, force: true });
+    await fs.promises.rm(storagePath, { recursive: true, force: true });
+  });
+
+  test('load returns null for stale signature and invalidate removes config entries', async () => {
+    const configPath = await makeTempDir('1cviewer-type-cache-cfg-');
+    const storagePath = await makeTempDir('1cviewer-type-cache-store-');
+    const typePath = path.join(configPath, 'Documents');
+    await fs.promises.mkdir(typePath, { recursive: true });
+    await fs.promises.writeFile(path.join(typePath, 'Order.xml'), '<MetaDataObject/>', 'utf-8');
+
+    const signature = await computeTypeContentsSignature(typePath, ConfigFormat.Designer);
+    assert.ok(signature);
+    await saveTypeContentsToCache(storagePath, configPath, 'Documents', signature, [
+      { id: 'Documents.Order', name: 'Order', type: MetadataType.Document, properties: {} },
+    ]);
+
+    assert.strictEqual(await loadTypeContentsFromCache(storagePath, configPath, 'Documents', 'stale'), null);
+    await invalidateTypeContentsCache(storagePath, configPath);
+    assert.strictEqual(await loadTypeContentsFromCache(storagePath, configPath, 'Documents', signature), null);
+
+    await fs.promises.rm(configPath, { recursive: true, force: true });
+    await fs.promises.rm(storagePath, { recursive: true, force: true });
+  });
+
+  test('clearTypeContentsCache removes all cache entries', async () => {
+    const configPath = await makeTempDir('1cviewer-type-cache-cfg-');
+    const storagePath = await makeTempDir('1cviewer-type-cache-store-');
+    const typePath = path.join(configPath, 'Enums');
+    await fs.promises.mkdir(typePath, { recursive: true });
+    await fs.promises.writeFile(path.join(typePath, 'Status.xml'), '<MetaDataObject/>', 'utf-8');
+
+    const signature = await computeTypeContentsSignature(typePath, ConfigFormat.Designer);
+    assert.ok(signature);
+    await saveTypeContentsToCache(storagePath, configPath, 'Enums', signature, [
+      { id: 'Enums.Status', name: 'Status', type: MetadataType.Enum, properties: {} },
+    ]);
+    assert.ok(await loadTypeContentsFromCache(storagePath, configPath, 'Enums', signature));
+
+    await clearTypeContentsCache(storagePath);
+    assert.strictEqual(await loadTypeContentsFromCache(storagePath, configPath, 'Enums', signature), null);
+
+    await fs.promises.rm(configPath, { recursive: true, force: true });
+    await fs.promises.rm(storagePath, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Что сделано

- Ускорен поиск конфигураций: сканер больше не проваливается внутрь уже найденных конфигураций, но продолжает искать конфигурации в произвольной вложенности workspace.
- Добавлен дисковый кэш содержимого папок типов (`parseTypeContents`) с лёгкой проверкой свежести.
- Lazy/eager пути дерева, TypeEditor, ObjectTypeEditor и редактор ролей используют общий кэш и уже известный формат конфигурации без повторного `detect`.
- После первого показа дерева запускается фоновый прогрев type-cache с приоритетом тяжёлых/частых типов.

## Проверка

- `npx tsc -p tsconfig.test.json`
- `npm run lint`
- `npm run compile`
- `cmd /c test-suite.bat`
- `git diff --check`
- Perf smoke на `FormatSamples/uh`: `Catalogs + Documents + Enums` холодно 29.5с, повтор из type-cache 1.76с; discovery `FormatSamples` ранее 18мс.