### PR TITLE
Prioritize foreground lazy metadata loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.48.8",
+  "version": "0.48.9",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/src/parsers/metadataParser.ts
+++ b/src/parsers/metadataParser.ts
@@ -44,6 +44,7 @@ const R6_OBJECT_TYPES = new Set<MetadataType>([
  */
 export class MetadataParser {
   private static typeContentsCacheStoragePath: string | null = null;
+  private static readonly inFlightTypeContents = new Map<string, Promise<TreeNode[]>>();
 
   static setTypeContentsCacheStoragePath(storagePath: string | null): void {
     this.typeContentsCacheStoragePath = storagePath && storagePath.trim() ? storagePath : null;
@@ -71,6 +72,14 @@ export class MetadataParser {
       return path.join(configPath, 'src', typeName);
     }
     return null;
+  }
+
+  private static getTypeContentsInFlightKey(
+    configPath: string,
+    typeName: string,
+    format: ConfigFormat
+  ): string {
+    return `${format}:${path.normalize(configPath).toLowerCase()}:${typeName}`;
   }
 
   private static async parseTypeContentsUncached(
@@ -118,9 +127,36 @@ export class MetadataParser {
     options?: { format?: ConfigFormat; bypassCache?: boolean }
   ): Promise<TreeNode[]> {
     const format = options?.format ?? await FormatDetector.detect(configPath);
+    if (options?.bypassCache === true) {
+      return await this.parseTypeContentsUncached(configPath, typeName, format);
+    }
+
+    const inFlightKey = this.getTypeContentsInFlightKey(configPath, typeName, format);
+    const existing = this.inFlightTypeContents.get(inFlightKey);
+    if (existing) {
+      return await existing;
+    }
+
+    const pending = (async () => {
+      return await this.parseTypeContentsWithCache(configPath, typeName, format);
+    })().finally(() => {
+      if (this.inFlightTypeContents.get(inFlightKey) === pending) {
+        this.inFlightTypeContents.delete(inFlightKey);
+      }
+    });
+
+    this.inFlightTypeContents.set(inFlightKey, pending);
+    return await pending;
+  }
+
+  private static async parseTypeContentsWithCache(
+    configPath: string,
+    typeName: string,
+    format: ConfigFormat
+  ): Promise<TreeNode[]> {
     const typePath = this.getTypePath(configPath, typeName, format);
     const storagePath = this.typeContentsCacheStoragePath;
-    if (!typePath || options?.bypassCache === true || !storagePath) {
+    if (!typePath || !storagePath) {
       return await this.parseTypeContentsUncached(configPath, typeName, format);
     }
 

--- a/src/providers/treeDataProvider.ts
+++ b/src/providers/treeDataProvider.ts
@@ -591,6 +591,10 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     }, delayMs);
   }
 
+  private stopTypeContentsCacheWarmup(): void {
+    this.typeContentsWarmupGeneration++;
+  }
+
   private collectWarmupTypeFolders(root: TreeNode): TreeNode[] {
     const folders: TreeNode[] = [];
     for (const child of root.children ?? []) {
@@ -842,6 +846,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
       // Lazy load: type node with no children yet
       if (this.isLazyTypeNode(activeElement)) {
+        this.stopTypeContentsCacheWarmup();
         const configRoot = this.cache.getConfigurationRoot(activeElement);
         const ctx = configRoot ? this.cache.getLoadContext(configRoot.id) : undefined;
         if (!ctx) {return Promise.resolve([]);}

--- a/test/suite/metadataParser.edge.test.ts
+++ b/test/suite/metadataParser.edge.test.ts
@@ -107,6 +107,51 @@ suite('MetadataParser edge branches', () => {
     }
   });
 
+  test('parseTypeContents joins concurrent requests for the same type folder', async () => {
+    const configPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-cache-inflight-cfg-'));
+    const storagePath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-cache-inflight-store-'));
+    await fs.promises.mkdir(path.join(configPath, 'Catalogs'), { recursive: true });
+    await fs.promises.writeFile(path.join(configPath, 'Catalogs', 'Goods.xml'), '<MetaDataObject/>', 'utf-8');
+
+    const originalDetect = FormatDetector.detect;
+    const originalDesigner = DesignerParser.parseTypeContents;
+    let parseCount = 0;
+    let releaseParse!: () => void;
+    const parseBarrier = new Promise<void>((resolve) => {
+      releaseParse = resolve;
+    });
+    try {
+      MetadataParser.setTypeContentsCacheStoragePath(storagePath);
+      (FormatDetector.detect as unknown as (p: string) => Promise<ConfigFormat>) = async () => ConfigFormat.Designer;
+      (DesignerParser.parseTypeContents as unknown as (a: string, b: string) => Promise<TreeNode[]>) = async () => {
+        parseCount += 1;
+        await parseBarrier;
+        return [{ id: 'Catalogs.Goods', name: 'Goods', type: MetadataType.Catalog, properties: {} }];
+      };
+
+      const first = MetadataParser.parseTypeContents(configPath, 'Catalogs');
+      while (parseCount === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      const second = MetadataParser.parseTypeContents(configPath, 'Catalogs');
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      releaseParse();
+
+      const [firstChildren, secondChildren] = await Promise.all([first, second]);
+
+      assert.strictEqual(firstChildren[0].id, 'Catalogs.Goods');
+      assert.strictEqual(secondChildren[0].id, 'Catalogs.Goods');
+      assert.strictEqual(parseCount, 1, 'concurrent callers must share one parse operation');
+    } finally {
+      releaseParse?.();
+      MetadataParser.setTypeContentsCacheStoragePath(null);
+      (FormatDetector.detect as unknown as typeof FormatDetector.detect) = originalDetect;
+      (DesignerParser.parseTypeContents as unknown as typeof DesignerParser.parseTypeContents) = originalDesigner;
+      await fs.promises.rm(configPath, { recursive: true, force: true });
+      await fs.promises.rm(storagePath, { recursive: true, force: true });
+    }
+  });
+
   test('loadElementChildren covers R6 placeholder branch and generic branch', async () => {
     const originalDesignerLoad = DesignerParser.loadChildrenForElement;
     const originalEdtLoad = EdtParser.loadChildrenForElement;

--- a/test/suite/treeDataProvider.test.ts
+++ b/test/suite/treeDataProvider.test.ts
@@ -510,6 +510,63 @@ suite('MetadataTreeDataProvider Test Suite', () => {
     }
   });
 
+  test('getChildren for a lazy type folder stops remaining background type warmup', async () => {
+    const originalParseTypeContents = MetadataParser.parseTypeContents;
+    const parseCalls: string[] = [];
+    let releaseWarmupCatalogs!: () => void;
+    const warmupCatalogsBarrier = new Promise<void>((resolve) => {
+      releaseWarmupCatalogs = resolve;
+    });
+
+    let catalogsCalls = 0;
+    (MetadataParser as any).parseTypeContents = async (_configPath: string, typeName: string) => {
+      parseCalls.push(typeName);
+      if (typeName === 'Catalogs') {
+        catalogsCalls += 1;
+        if (catalogsCalls === 1) {
+          await warmupCatalogsBarrier;
+        }
+        return [{ id: 'Catalogs.Goods', name: 'Goods', type: MetadataType.Catalog, properties: {} }];
+      }
+      return [{ id: `${typeName}.Item`, name: 'Item', type: MetadataType.Document, properties: {} }];
+    };
+
+    try {
+      const cfgPath = path.join('C:', 'cfg');
+      const root: TreeNode = {
+        id: 'root',
+        name: 'Configuration',
+        type: MetadataType.Configuration,
+        properties: {},
+        filePath: path.join(cfgPath, 'Configuration.xml'),
+        children: [
+          { id: 'Catalogs', name: 'Catalogs', type: MetadataType.Catalog, properties: {}, children: [] },
+          { id: 'Documents', name: 'Documents', type: MetadataType.Document, properties: {}, children: [] },
+        ],
+      };
+      for (const child of root.children!) {
+        child.parent = root;
+      }
+      provider.setRootNode(root, { configPath: cfgPath, format: ConfigFormat.Designer });
+      provider.startTypeContentsCacheWarmup(0);
+
+      while (!parseCalls.includes('Catalogs')) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+
+      const foregroundChildren = await provider.getChildren(root.children![0]);
+      assert.deepStrictEqual(foregroundChildren.map((n) => n.name), ['Goods']);
+
+      releaseWarmupCatalogs();
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      assert.ok(!parseCalls.includes('Documents'), 'foreground lazy load must stop remaining warmup items');
+    } finally {
+      releaseWarmupCatalogs?.();
+      MetadataParser.parseTypeContents = originalParseTypeContents;
+    }
+  });
+
   test('setRootNodes resolves stale ref in correct root when multi-root branches are identical', async () => {
     const makeFormsBranch = (formName: string): { root: TreeNode; forms: TreeNode } => {
       const forms: TreeNode = {


### PR DESCRIPTION
## Что сделано
- Убрано дублирование тяжелого `parseTypeContents` для одного type-folder: foreground-клик и background-warmup теперь разделяют один in-flight Promise.
- Пользовательское раскрытие lazy type-folder останавливает оставшуюся очередь background-warmup после текущего элемента.
- Добавлены регрессионные тесты на оба сценария.

## Проверка
- `npm run lint`
- `npm run compile`
- `node out/test/runCore.js`
- `npm run test:coverage`
- `npm run coverage:check`