### PR TITLE
Speed up TypeEditor warmup reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.48.9",
+  "version": "0.49.0",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/src/parsers/designerParser.ts
+++ b/src/parsers/designerParser.ts
@@ -193,6 +193,50 @@ export class DesignerParser {
   }
 
   /**
+   * Build only direct object nodes for a metadata type without parsing object XML.
+   * This is used by tree warmup and first type-folder expansion where the UI needs
+   * a fast object list; per-object details stay lazy.
+   */
+  static async parseTypeIndex(configPath: string, typeName: string): Promise<TreeNode[]> {
+    const typePath = path.join(configPath, typeName);
+    const metadataType = MetadataTypeMapper.map(typeName);
+
+    if (typeName === 'Subsystems') {
+      const typeNode = await this.parseMetadataType(typePath, typeName, { shallow: true });
+      return typeNode.children || [];
+    }
+
+    const entries = await fs.promises.readdir(typePath, { withFileTypes: true }).catch(() => [] as fs.Dirent[]);
+    const directoryNames = new Set<string>();
+    const flatXmlNames = new Set<string>();
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        directoryNames.add(entry.name);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.xml')) {
+        flatXmlNames.add(path.basename(entry.name, path.extname(entry.name)));
+      }
+    }
+
+    const names = new Set<string>([...directoryNames, ...flatXmlNames]);
+    return Array.from(names)
+      .sort((a, b) => a.localeCompare(b, 'ru', { sensitivity: 'base' }))
+      .map((name) => {
+        const flatXmlPath = path.join(typePath, `${name}.xml`);
+        const directoryPath = path.join(typePath, name);
+        const filePath = flatXmlNames.has(name) ? flatXmlPath : directoryPath;
+        return {
+          id: `${typeName}.${name}`,
+          name,
+          type: metadataType,
+          properties: { type: typeName, _lazy: true },
+          children: [],
+          filePath,
+        };
+      });
+  }
+
+  /**
    * Load direct children (Attributes, Forms, Ext, TabularSections) for a metadata element.
    * For Subsystems, child subsystems are already in the tree; path is derived from element.filePath when provided.
    */

--- a/src/parsers/edtParser.ts
+++ b/src/parsers/edtParser.ts
@@ -178,6 +178,34 @@ export class EdtParser {
   }
 
   /**
+   * Build only direct object nodes for a metadata type without parsing .mdo/XML.
+   * Per-object details are loaded later through loadChildrenForElement.
+   */
+  static async parseTypeIndex(configPath: string, typeName: string): Promise<TreeNode[]> {
+    const typePath = path.join(configPath, 'src', typeName);
+    const metadataType = MetadataTypeMapper.map(typeName);
+
+    if (typeName === 'Subsystems') {
+      const typeNode = await this.parseMetadataType(typePath, typeName, { shallow: true });
+      return typeNode.children || [];
+    }
+
+    const entries = await fs.promises.readdir(typePath, { withFileTypes: true }).catch(() => [] as fs.Dirent[]);
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b, 'ru', { sensitivity: 'base' }))
+      .map((name) => ({
+        id: `${typeName}.${name}`,
+        name,
+        type: metadataType,
+        properties: { type: typeName, _lazy: true },
+        children: [],
+        filePath: path.join(typePath, name),
+      }));
+  }
+
+  /**
    * Load direct children (Attributes, TabularSections from .mdo; Forms, Ext from filesystem) for a metadata element.
    * For Subsystems, child subsystems are already in the tree; path is derived from element.filePath when provided.
    */

--- a/src/parsers/metadataParser.ts
+++ b/src/parsers/metadataParser.ts
@@ -45,6 +45,7 @@ const R6_OBJECT_TYPES = new Set<MetadataType>([
 export class MetadataParser {
   private static typeContentsCacheStoragePath: string | null = null;
   private static readonly inFlightTypeContents = new Map<string, Promise<TreeNode[]>>();
+  private static readonly inFlightTypeIndex = new Map<string, Promise<TreeNode[]>>();
 
   static setTypeContentsCacheStoragePath(storagePath: string | null): void {
     this.typeContentsCacheStoragePath = storagePath && storagePath.trim() ? storagePath : null;
@@ -110,6 +111,26 @@ export class MetadataParser {
     return [];
   }
 
+  private static cloneTreeNode(node: TreeNode, parent?: TreeNode): TreeNode {
+    const clone: TreeNode = {
+      id: node.id,
+      name: node.name,
+      type: node.type,
+      properties: { ...node.properties },
+      filePath: node.filePath,
+      parentFilePath: node.parentFilePath,
+      parent,
+    };
+    if (node.children) {
+      clone.children = node.children.map((child) => this.cloneTreeNode(child, clone));
+    }
+    return clone;
+  }
+
+  private static cloneTreeNodes(nodes: readonly TreeNode[]): TreeNode[] {
+    return nodes.map((node) => this.cloneTreeNode(node));
+  }
+
   /**
    * Build only root and type nodes without loading element contents (for lazy loading).
    * @param configPath Path to configuration root directory
@@ -173,7 +194,20 @@ export class MetadataParser {
     options?: { format?: ConfigFormat }
   ): Promise<TreeNode[]> {
     const format = options?.format ?? await FormatDetector.detect(configPath);
-    return await this.parseTypeIndexUncached(configPath, typeName, format);
+    const inFlightKey = this.getTypeContentsInFlightKey(configPath, typeName, format);
+    const existing = this.inFlightTypeIndex.get(inFlightKey);
+    if (existing) {
+      return this.cloneTreeNodes(await existing);
+    }
+
+    const pending = this.parseTypeIndexUncached(configPath, typeName, format).finally(() => {
+      if (this.inFlightTypeIndex.get(inFlightKey) === pending) {
+        this.inFlightTypeIndex.delete(inFlightKey);
+      }
+    });
+
+    this.inFlightTypeIndex.set(inFlightKey, pending);
+    return this.cloneTreeNodes(await pending);
   }
 
   private static async parseTypeContentsWithCache(

--- a/src/parsers/metadataParser.ts
+++ b/src/parsers/metadataParser.ts
@@ -96,6 +96,20 @@ export class MetadataParser {
     return [];
   }
 
+  private static async parseTypeIndexUncached(
+    configPath: string,
+    typeName: string,
+    format: ConfigFormat
+  ): Promise<TreeNode[]> {
+    if (format === ConfigFormat.Designer) {
+      return await DesignerParser.parseTypeIndex(configPath, typeName);
+    }
+    if (format === ConfigFormat.EDT) {
+      return await EdtParser.parseTypeIndex(configPath, typeName);
+    }
+    return [];
+  }
+
   /**
    * Build only root and type nodes without loading element contents (for lazy loading).
    * @param configPath Path to configuration root directory
@@ -147,6 +161,19 @@ export class MetadataParser {
 
     this.inFlightTypeContents.set(inFlightKey, pending);
     return await pending;
+  }
+
+  /**
+   * Load only direct object nodes for a metadata type without parsing every object XML.
+   * This is the fast path for tree type-folder expansion and background warmup.
+   */
+  static async parseTypeIndex(
+    configPath: string,
+    typeName: string,
+    options?: { format?: ConfigFormat }
+  ): Promise<TreeNode[]> {
+    const format = options?.format ?? await FormatDetector.detect(configPath);
+    return await this.parseTypeIndexUncached(configPath, typeName, format);
   }
 
   private static async parseTypeContentsWithCache(

--- a/src/providers/objectTypeLoader.ts
+++ b/src/providers/objectTypeLoader.ts
@@ -63,7 +63,7 @@ export function getObjectableObjects(rootNodes: readonly TreeNode[]): Objectable
 
 /**
  * Returns object-kind groups for the ObjectTypeEditor, ensuring that the underlying
- * metadata type nodes are loaded (parallel lazy load via MetadataParser.parseTypeContents).
+ * metadata type nodes are loaded (parallel lazy load via MetadataParser.parseTypeIndex).
  */
 export async function getObjectableObjectsForEditor(
   node: TreeNode | undefined,
@@ -110,7 +110,7 @@ export async function getObjectableObjectsForEditor(
     const settled = await Promise.all(
       loadTasks.map(async ({ typeNode, configPath, format }) => {
         try {
-          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id, { format });
+          const children = await MetadataParser.parseTypeIndex(configPath, typeNode.id, { format });
           return { typeNode, children };
         } catch (e) {
           Logger.warn('Failed to eager load objectable type contents for object type editor', {

--- a/src/providers/treeDataProvider.ts
+++ b/src/providers/treeDataProvider.ts
@@ -52,6 +52,7 @@ const TYPE_CONTENTS_WARMUP_PRIORITY = new Map<string, number>([
   ['Constants', 8],
   ['CommonPictures', 9],
 ]);
+const TYPE_CONTENTS_WARMUP_RESUME_AFTER_FOREGROUND_MS = 1000;
 
 /**
  * Tree Data Provider for VS Code Tree View
@@ -71,6 +72,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
   /** Snapshot of objectable object groups per scope for ObjectTypeEditor (invalidated with tree reload / structure). */
   private readonly objectableObjectsCache = new Map<string, ObjectableGroup[]>();
   private typeContentsWarmupGeneration = 0;
+  private typeContentsWarmupTimer: ReturnType<typeof setTimeout> | null = null;
 
   private messageUpdater: ((message: string | undefined) => void) | null = null;
   /** Ключ {@link bindingKey}(workspaceFolder, configRelativePath) → сводка для узла Configuration. */
@@ -496,6 +498,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
       Logger.error('Cannot set null or undefined root node');
       return;
     }
+    this.cancelTypeContentsCacheWarmup();
     this.rootNodes = [node];
     this.cache.clearLoadContexts();
     if (loadContext) {this.cache.setLoadContext(node.id, loadContext);}
@@ -517,6 +520,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     nodes: TreeNode[],
     loadContextMap?: Map<string, { configPath: string; format: ConfigFormat }>
   ): void {
+    this.cancelTypeContentsCacheWarmup();
     this.rootNodes = nodes;
     this.cache.setLoadContexts(loadContextMap ?? new Map());
     this.cache.clear();
@@ -579,20 +583,31 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
   }
 
   startTypeContentsCacheWarmup(delayMs = 1000): void {
+    this.clearScheduledTypeContentsCacheWarmup();
     const generation = ++this.typeContentsWarmupGeneration;
     const roots = [...this.rootNodes];
     if (roots.length === 0) {
       return;
     }
-    setTimeout(() => {
+    this.typeContentsWarmupTimer = setTimeout(() => {
+      this.typeContentsWarmupTimer = null;
       void this.warmUpTypeContentsCache(roots, generation).catch((error) => {
         Logger.warn('Type contents cache warmup failed', error);
       });
     }, delayMs);
   }
 
-  private stopTypeContentsCacheWarmup(): void {
+  private clearScheduledTypeContentsCacheWarmup(): void {
+    if (!this.typeContentsWarmupTimer) {
+      return;
+    }
+    clearTimeout(this.typeContentsWarmupTimer);
+    this.typeContentsWarmupTimer = null;
+  }
+
+  private cancelTypeContentsCacheWarmup(): void {
     this.typeContentsWarmupGeneration++;
+    this.clearScheduledTypeContentsCacheWarmup();
   }
 
   private collectWarmupTypeFolders(root: TreeNode): TreeNode[] {
@@ -846,10 +861,10 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
       // Lazy load: type node with no children yet
       if (this.isLazyTypeNode(activeElement)) {
-        this.stopTypeContentsCacheWarmup();
         const configRoot = this.cache.getConfigurationRoot(activeElement);
         const ctx = configRoot ? this.cache.getLoadContext(configRoot.id) : undefined;
         if (!ctx) {return Promise.resolve([]);}
+        this.cancelTypeContentsCacheWarmup();
         return MetadataParser.parseTypeContents(ctx.configPath, activeElement.id, { format: ctx.format }).then((children) => {
           for (const c of children) {
             c.parent = activeElement;
@@ -869,6 +884,8 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
           this.filter.ensureFilterSets(this.cache.nodes);
           const ids = this.filter.filterAncestorOrVisibleIds!;
           return children.filter((c) => ids.has(c.id));
+        }).finally(() => {
+          this.startTypeContentsCacheWarmup(TYPE_CONTENTS_WARMUP_RESUME_AFTER_FOREGROUND_MS);
         });
       }
 

--- a/src/providers/treeDataProvider.ts
+++ b/src/providers/treeDataProvider.ts
@@ -351,7 +351,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
         Logger.info('Eager loading type for subsystem filter', { folder });
         try {
-          const children = await MetadataParser.parseTypeContents(ctx.configPath, folder, { format: ctx.format });
+          const children = await MetadataParser.parseTypeIndex(ctx.configPath, folder, { format: ctx.format });
           for (const c of children) {
             c.parent = typeNode;
             this.cache.buildCache(c);
@@ -569,7 +569,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
       if (!this.isLazyTypeNode(typeFolder)) { continue; }
 
       try {
-        const children = await MetadataParser.parseTypeContents(ctx.configPath, typeFolder.id, { format: ctx.format });
+        const children = await MetadataParser.parseTypeIndex(ctx.configPath, typeFolder.id, { format: ctx.format });
         for (const c of children) {
           c.parent = typeFolder;
           this.cache.buildCache(c);
@@ -651,7 +651,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
           continue;
         }
         const startedAt = Date.now();
-        await MetadataParser.parseTypeContents(ctx.configPath, typeFolder.id, { format: ctx.format });
+        await MetadataParser.parseTypeIndex(ctx.configPath, typeFolder.id, { format: ctx.format });
         const durationMs = Date.now() - startedAt;
         if (durationMs >= 1000) {
           Logger.info('Type contents cache warmup item completed', { typeName: typeFolder.id, durationMs });
@@ -865,7 +865,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
         const ctx = configRoot ? this.cache.getLoadContext(configRoot.id) : undefined;
         if (!ctx) {return Promise.resolve([]);}
         this.cancelTypeContentsCacheWarmup();
-        return MetadataParser.parseTypeContents(ctx.configPath, activeElement.id, { format: ctx.format }).then((children) => {
+        return MetadataParser.parseTypeIndex(ctx.configPath, activeElement.id, { format: ctx.format }).then((children) => {
           for (const c of children) {
             c.parent = activeElement;
             this.cache.buildCache(c);

--- a/src/providers/treeDataProvider.ts
+++ b/src/providers/treeDataProvider.ts
@@ -351,12 +351,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
 
         Logger.info('Eager loading type for subsystem filter', { folder });
         try {
-          const children = await MetadataParser.parseTypeIndex(ctx.configPath, folder, { format: ctx.format });
-          for (const c of children) {
-            c.parent = typeNode;
-            this.cache.buildCache(c);
-          }
-          typeNode.children = children;
+          await this.populateTypeFolderIndex(typeNode, ctx);
         } catch (error) {
           Logger.warn('Failed to eager load type for subsystem filter', { folder, error });
         }
@@ -569,17 +564,11 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
       if (!this.isLazyTypeNode(typeFolder)) { continue; }
 
       try {
-        const children = await MetadataParser.parseTypeIndex(ctx.configPath, typeFolder.id, { format: ctx.format });
-        for (const c of children) {
-          c.parent = typeFolder;
-          this.cache.buildCache(c);
-        }
-        typeFolder.children = children;
+        await this.populateTypeFolderIndex(typeFolder, ctx);
       } catch (error) {
         Logger.warn('Failed to eager load type folder', { folder: typeFolder.id, error });
       }
     }
-    this.clearTypeEditorReferenceableCache();
   }
 
   startTypeContentsCacheWarmup(delayMs = 1000): void {
@@ -651,7 +640,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
           continue;
         }
         const startedAt = Date.now();
-        await MetadataParser.parseTypeIndex(ctx.configPath, typeFolder.id, { format: ctx.format });
+        await this.populateTypeFolderIndex(typeFolder, ctx);
         const durationMs = Date.now() - startedAt;
         if (durationMs >= 1000) {
           Logger.info('Type contents cache warmup item completed', { typeName: typeFolder.id, durationMs });
@@ -659,6 +648,25 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
     }
+  }
+
+  private async populateTypeFolderIndex(
+    typeFolder: TreeNode,
+    ctx: { configPath: string; format: ConfigFormat }
+  ): Promise<TreeNode[]> {
+    if (typeFolder.children && typeFolder.children.length > 0) {
+      return typeFolder.children;
+    }
+
+    const children = await MetadataParser.parseTypeIndex(ctx.configPath, typeFolder.id, { format: ctx.format });
+    for (const c of children) {
+      c.parent = typeFolder;
+      this.cache.buildCache(c);
+      ensureR6PlaceholdersForInstanceNode(c, { configPath: ctx.configPath, format: ctx.format });
+    }
+    typeFolder.children = children;
+    this.clearTypeEditorReferenceableCache();
+    return children;
   }
 
   /**
@@ -865,15 +873,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<TreeNod
         const ctx = configRoot ? this.cache.getLoadContext(configRoot.id) : undefined;
         if (!ctx) {return Promise.resolve([]);}
         this.cancelTypeContentsCacheWarmup();
-        return MetadataParser.parseTypeIndex(ctx.configPath, activeElement.id, { format: ctx.format }).then((children) => {
-          for (const c of children) {
-            c.parent = activeElement;
-            this.cache.buildCache(c);
-          }
-          activeElement.children = children;
-          for (const c of children) {
-            ensureR6PlaceholdersForInstanceNode(c, { configPath: ctx.configPath, format: ctx.format });
-          }
+        return this.populateTypeFolderIndex(activeElement, ctx).then((children) => {
           Logger.info('Tree cache size after lazy load', {
             type: activeElement.id,
             nodeCount: this.cache.size,

--- a/src/providers/treeReferenceLoader.ts
+++ b/src/providers/treeReferenceLoader.ts
@@ -222,7 +222,7 @@ export async function getReferenceableObjectsForTypeEditor(
     const settled = await Promise.all(
       loadTasks.map(async ({ typeNode, configPath, format }) => {
         try {
-          const children = await MetadataParser.parseTypeContents(configPath, typeNode.id, { format });
+          const children = await MetadataParser.parseTypeIndex(configPath, typeNode.id, { format });
           return { typeNode, children };
         } catch (e) {
           Logger.warn('Failed to eager load referenceable type contents for type editor', {

--- a/test/suite/designerParser.test.ts
+++ b/test/suite/designerParser.test.ts
@@ -1,7 +1,9 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { DesignerParser } from '../../src/parsers/designerParser';
+import { XmlParser } from '../../src/parsers/xmlParser';
 import { MetadataType, TreeNode } from '../../src/models/treeNode';
 import {
   ensureTabularSectionColumnsPlaceholder,
@@ -180,6 +182,32 @@ suite('DesignerParser', () => {
     assert.ok(names.includes('Справочник55'), 'flat xml Справочник55.xml');
     assert.ok(names.includes('СтарееСтарых'), 'flat xml СтарееСтарых.xml');
     assert.ok(names.includes('табатаба'), 'flat xml табатаба.xml');
+  });
+
+  test('parseTypeIndex lists flat and directory objects without parsing object XML', async () => {
+    const configPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-index-'));
+    const catalogsPath = path.join(configPath, 'Catalogs');
+    const originalParseFileAsync = XmlParser.parseFileAsync;
+    await fs.promises.mkdir(path.join(catalogsPath, 'FolderCatalog'), { recursive: true });
+    await fs.promises.writeFile(path.join(catalogsPath, 'FolderCatalog.xml'), '<MetaDataObject/>', 'utf-8');
+    await fs.promises.writeFile(path.join(catalogsPath, 'FlatCatalog.xml'), '<broken>', 'utf-8');
+    await fs.promises.writeFile(path.join(catalogsPath, 'readme.txt'), 'skip', 'utf-8');
+
+    try {
+      (XmlParser.parseFileAsync as unknown as typeof XmlParser.parseFileAsync) = async () => {
+        throw new Error('parseTypeIndex must not parse object XML');
+      };
+
+      const children = await (DesignerParser as any).parseTypeIndex(configPath, 'Catalogs') as TreeNode[];
+      const names = children.map((c) => c.name);
+
+      assert.deepStrictEqual(names, ['FlatCatalog', 'FolderCatalog']);
+      assert.ok(children.every((c) => c.properties._lazy === true));
+      assert.ok(children.every((c) => c.children?.length === 0));
+    } finally {
+      XmlParser.parseFileAsync = originalParseFileAsync;
+      await fs.promises.rm(configPath, { recursive: true, force: true });
+    }
   });
 
   test('should parse extensions_samples if present (configuration extension with Ext)', async function () {

--- a/test/suite/metadataParser.edge.test.ts
+++ b/test/suite/metadataParser.edge.test.ts
@@ -152,6 +152,43 @@ suite('MetadataParser edge branches', () => {
     }
   });
 
+  test('parseTypeIndex joins concurrent requests for the same type folder', async () => {
+    const originalDetect = FormatDetector.detect;
+    const originalDesigner = DesignerParser.parseTypeIndex;
+    let parseCount = 0;
+    let releaseParse!: () => void;
+    const parseBarrier = new Promise<void>((resolve) => {
+      releaseParse = resolve;
+    });
+
+    try {
+      (FormatDetector.detect as unknown as (p: string) => Promise<ConfigFormat>) = async () => ConfigFormat.Designer;
+      (DesignerParser.parseTypeIndex as unknown as (a: string, b: string) => Promise<TreeNode[]>) = async () => {
+        parseCount += 1;
+        await parseBarrier;
+        return [{ id: 'Catalogs.Goods', name: 'Goods', type: MetadataType.Catalog, properties: {} }];
+      };
+
+      const first = MetadataParser.parseTypeIndex('cfg', 'Catalogs');
+      while (parseCount === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      const second = MetadataParser.parseTypeIndex('cfg', 'Catalogs');
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      releaseParse();
+
+      const [firstChildren, secondChildren] = await Promise.all([first, second]);
+
+      assert.strictEqual(firstChildren[0].id, 'Catalogs.Goods');
+      assert.strictEqual(secondChildren[0].id, 'Catalogs.Goods');
+      assert.strictEqual(parseCount, 1, 'concurrent index callers must share one parse operation');
+    } finally {
+      releaseParse?.();
+      (FormatDetector.detect as unknown as typeof FormatDetector.detect) = originalDetect;
+      (DesignerParser.parseTypeIndex as unknown as typeof DesignerParser.parseTypeIndex) = originalDesigner;
+    }
+  });
+
   test('loadElementChildren covers R6 placeholder branch and generic branch', async () => {
     const originalDesignerLoad = DesignerParser.loadChildrenForElement;
     const originalEdtLoad = EdtParser.loadChildrenForElement;

--- a/test/suite/treeDataProvider.test.ts
+++ b/test/suite/treeDataProvider.test.ts
@@ -409,13 +409,17 @@ suite('MetadataTreeDataProvider Test Suite', () => {
   });
 
   test('getChildren resolves stale lazy type node against reloaded root context', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const parseCalls: Array<{ configPath: string; typeName: string }> = [];
-    (MetadataParser as any).parseTypeContents = async (configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (configPath: string, typeName: string) => {
       parseCalls.push({ configPath, typeName });
       return [
         { id: `${typeName}.Reloaded`, name: 'ReloadedCatalog', type: MetadataType.Catalog, properties: {} },
       ];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('lazy type expansion must use parseTypeIndex');
     };
 
     try {
@@ -449,20 +453,25 @@ suite('MetadataTreeDataProvider Test Suite', () => {
 
       const children = await provider.getChildren(staleCatalogsRef);
       assert.deepStrictEqual(children.map((n) => n.name), ['ReloadedCatalog']);
-      assert.strictEqual(parseCalls.length, 1, 'parseTypeContents should be called exactly once');
+      assert.strictEqual(parseCalls.length, 1, 'parseTypeIndex should be called exactly once');
       assert.strictEqual(parseCalls[0].typeName, 'Catalogs');
       assert.strictEqual(parseCalls[0].configPath, path.join('C:', 'cfgA'));
     } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });
 
   test('getChildren lazy-loads Roles under Общие using Configuration root load context', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const parseCalls: Array<{ configPath: string; typeName: string }> = [];
-    (MetadataParser as any).parseTypeContents = async (configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (configPath: string, typeName: string) => {
       parseCalls.push({ configPath, typeName });
       return [{ id: 'Roles.R1', name: 'R1', type: MetadataType.Role, properties: {} }];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('lazy type expansion must use parseTypeIndex');
     };
 
     try {
@@ -506,11 +515,13 @@ suite('MetadataTreeDataProvider Test Suite', () => {
       assert.strictEqual(parseCalls[0].configPath, cfgPath);
       assert.strictEqual(parseCalls[0].typeName, 'Roles');
     } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });
 
   test('getChildren for a lazy type folder pauses then resumes background type warmup', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const parseCalls: string[] = [];
     let releaseWarmupCatalogs!: () => void;
@@ -519,7 +530,7 @@ suite('MetadataTreeDataProvider Test Suite', () => {
     });
 
     let catalogsCalls = 0;
-    (MetadataParser as any).parseTypeContents = async (_configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (_configPath: string, typeName: string) => {
       parseCalls.push(typeName);
       if (typeName === 'Catalogs') {
         catalogsCalls += 1;
@@ -529,6 +540,9 @@ suite('MetadataTreeDataProvider Test Suite', () => {
         return [{ id: 'Catalogs.Goods', name: 'Goods', type: MetadataType.Catalog, properties: {} }];
       }
       return [{ id: `${typeName}.Item`, name: 'Item', type: MetadataType.Document, properties: {} }];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('type warmup must use parseTypeIndex');
     };
 
     try {
@@ -566,6 +580,7 @@ suite('MetadataTreeDataProvider Test Suite', () => {
       assert.ok(parseCalls.includes('Documents'), 'background warmup must resume after foreground lazy load settles');
     } finally {
       releaseWarmupCatalogs?.();
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });
@@ -1056,10 +1071,11 @@ suite('MetadataTreeDataProvider Test Suite', () => {
   });
 
   test('getReferenceableObjectsForTypeEditor loads empty type children', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const calls: Array<{ configPath: string; typeName: string }> = [];
 
-    (MetadataParser as any).parseTypeContents = async (configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (configPath: string, typeName: string) => {
       calls.push({ configPath, typeName });
       if (typeName === 'Documents') {
         const node: TreeNode = {
@@ -1082,6 +1098,9 @@ suite('MetadataTreeDataProvider Test Suite', () => {
         return [node];
       }
       return [];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('type editor reference list must use parseTypeIndex');
     };
 
     try {
@@ -1118,18 +1137,20 @@ suite('MetadataTreeDataProvider Test Suite', () => {
 
       assert.ok(
         calls.some((c) => c.typeName === 'Documents'),
-        'parseTypeContents should be called for Documents when type node children are empty'
+        'parseTypeIndex should be called for Documents when type node children are empty'
       );
     } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });
 
   test('getReferenceableObjectsForTypeEditor caches result (no second parse pass)', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     let parseCalls = 0;
 
-    (MetadataParser as any).parseTypeContents = async (configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (configPath: string, typeName: string) => {
       parseCalls++;
       if (typeName === 'Documents') {
         return [
@@ -1143,6 +1164,9 @@ suite('MetadataTreeDataProvider Test Suite', () => {
         ];
       }
       return [];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('type editor reference list must use parseTypeIndex');
     };
 
     try {
@@ -1165,7 +1189,7 @@ suite('MetadataTreeDataProvider Test Suite', () => {
 
       provider.setRootNode(rootNode);
       await provider.getReferenceableObjectsForTypeEditor();
-      assert.ok(parseCalls > 0, 'first call should hit parseTypeContents');
+      assert.ok(parseCalls > 0, 'first call should hit parseTypeIndex');
       const afterFirst = parseCalls;
       await provider.getReferenceableObjectsForTypeEditor();
       assert.strictEqual(
@@ -1174,15 +1198,17 @@ suite('MetadataTreeDataProvider Test Suite', () => {
         'second call should use treeDataProvider cache and not parse again'
       );
     } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });
 
   test('getReferenceableObjectsForTypeEditor restricts to current config root', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const calls: Array<{ configPath: string; typeName: string }> = [];
 
-    (MetadataParser as any).parseTypeContents = async (configPath: string, typeName: string) => {
+    (MetadataParser as any).parseTypeIndex = async (configPath: string, typeName: string) => {
       calls.push({ configPath, typeName });
       if (typeName === 'Documents') {
         return [
@@ -1196,6 +1222,9 @@ suite('MetadataTreeDataProvider Test Suite', () => {
         ];
       }
       return [];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('type editor reference list must use parseTypeIndex');
     };
 
     try {
@@ -1286,13 +1315,14 @@ suite('MetadataTreeDataProvider Test Suite', () => {
       assert.ok(docRef, 'DocumentRef group must exist');
       assert.deepStrictEqual(docRef!.objectNames, ['Orders'], 'Only Orders from config A should be included');
 
-      // parseTypeContents should be called only for config A's missing Documents.
+      // parseTypeIndex should be called only for config A's missing Documents.
       assert.deepStrictEqual(
         calls.map((c) => c.typeName),
         ['Documents'],
-        'parseTypeContents should be called only once for Documents in the current config root'
+        'parseTypeIndex should be called only once for Documents in the current config root'
       );
     } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
       MetadataParser.parseTypeContents = originalParseTypeContents;
     }
   });

--- a/test/suite/treeDataProvider.test.ts
+++ b/test/suite/treeDataProvider.test.ts
@@ -510,7 +510,7 @@ suite('MetadataTreeDataProvider Test Suite', () => {
     }
   });
 
-  test('getChildren for a lazy type folder stops remaining background type warmup', async () => {
+  test('getChildren for a lazy type folder pauses then resumes background type warmup', async () => {
     const originalParseTypeContents = MetadataParser.parseTypeContents;
     const parseCalls: string[] = [];
     let releaseWarmupCatalogs!: () => void;
@@ -560,7 +560,10 @@ suite('MetadataTreeDataProvider Test Suite', () => {
       releaseWarmupCatalogs();
       await new Promise<void>((resolve) => setTimeout(resolve, 20));
 
-      assert.ok(!parseCalls.includes('Documents'), 'foreground lazy load must stop remaining warmup items');
+      assert.ok(!parseCalls.includes('Documents'), 'foreground lazy load must pause remaining warmup items immediately');
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 1200));
+      assert.ok(parseCalls.includes('Documents'), 'background warmup must resume after foreground lazy load settles');
     } finally {
       releaseWarmupCatalogs?.();
       MetadataParser.parseTypeContents = originalParseTypeContents;

--- a/test/suite/treeDataProvider.test.ts
+++ b/test/suite/treeDataProvider.test.ts
@@ -1203,6 +1203,96 @@ suite('MetadataTreeDataProvider Test Suite', () => {
     }
   });
 
+  test('getReferenceableObjectsForTypeEditor reuses type folders populated by warmup', async () => {
+    const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
+    const originalParseTypeContents = MetadataParser.parseTypeContents;
+    let allowParse = true;
+    const calls: string[] = [];
+
+    (MetadataParser as any).parseTypeIndex = async (_configPath: string, typeName: string) => {
+      if (!allowParse) {
+        throw new Error('type editor must reuse warmed tree children instead of reparsing');
+      }
+      calls.push(typeName);
+      if (typeName === 'Catalogs') {
+        return [
+          {
+            id: 'Catalogs.Products',
+            name: 'Products',
+            type: MetadataType.Catalog,
+            properties: {},
+            children: [],
+          },
+        ];
+      }
+      if (typeName === 'Documents') {
+        return [
+          {
+            id: 'Documents.Orders',
+            name: 'Orders',
+            type: MetadataType.Document,
+            properties: {},
+            children: [],
+          },
+        ];
+      }
+      return [];
+    };
+    (MetadataParser as any).parseTypeContents = async () => {
+      throw new Error('type editor reference list must use parseTypeIndex');
+    };
+
+    try {
+      const catalogNode: TreeNode = {
+        id: 'Catalogs',
+        name: 'Catalogs',
+        type: MetadataType.Catalog,
+        properties: {},
+        children: [],
+      };
+      const documentsNode: TreeNode = {
+        id: 'Documents',
+        name: 'Documents',
+        type: MetadataType.Document,
+        properties: {},
+        children: [],
+      };
+      const rootNode: TreeNode = {
+        id: 'root',
+        name: 'Configuration',
+        type: MetadataType.Configuration,
+        properties: {},
+        filePath: path.join('C:', 'reps', 'myconfig', 'Configuration.xml'),
+        children: [catalogNode, documentsNode],
+      };
+      catalogNode.parent = rootNode;
+      documentsNode.parent = rootNode;
+
+      provider.setRootNode(rootNode, { configPath: path.join('C:', 'reps', 'myconfig'), format: ConfigFormat.Designer });
+      provider.startTypeContentsCacheWarmup(0);
+
+      for (let i = 0; i < 20 && calls.length < 2; i++) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      assert.deepStrictEqual(calls.sort(), ['Catalogs', 'Documents']);
+
+      allowParse = false;
+      const result = await provider.getReferenceableObjectsForTypeEditor();
+
+      assert.deepStrictEqual(
+        result.find((g) => g.referenceKind === 'CatalogRef')?.objectNames,
+        ['Products']
+      );
+      assert.deepStrictEqual(
+        result.find((g) => g.referenceKind === 'DocumentRef')?.objectNames,
+        ['Orders']
+      );
+    } finally {
+      (MetadataParser as any).parseTypeIndex = originalParseTypeIndex;
+      MetadataParser.parseTypeContents = originalParseTypeContents;
+    }
+  });
+
   test('getReferenceableObjectsForTypeEditor restricts to current config root', async () => {
     const originalParseTypeIndex = (MetadataParser as any).parseTypeIndex;
     const originalParseTypeContents = MetadataParser.parseTypeContents;


### PR DESCRIPTION
## Что сделано
- Ускорен warmup папок типов: прогретый индекс теперь записывается в дерево и переиспользуется TypeEditor.
- Добавлена in-flight дедупликация `parseTypeIndex`, чтобы warmup и UI не читали одну папку параллельно.
- Собран релиз 0.49.0: обновлён `package.json`, добавлен VSIX.

## Проверка
- `npm run lint`
- `npm run compile`
- `npm run test:coverage`
- `npm run coverage:check`
- `npm run lint:test-promises`
- `build-all.bat`