### PR TITLE
Debugger Speed и безопасные locals

### DIFF
--- a/FormatSamples/empty_conf/Catalogs/Справочник55/Forms/Matrix_858451263b1b_a1_mo2z8b69_1b.xml
+++ b/FormatSamples/empty_conf/Catalogs/Справочник55/Forms/Matrix_858451263b1b_a1_mo2z8b69_1b.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Form uuid="743fd883-fc92-4cb6-b8c6-55ab3d3ccf42">
+		<Properties>
+			<Name>Matrix_858451263b1b_a1_mo2z8b69_1b</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>Matrix_858451263b1b_a1_mo2z8b69_1b</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+			<FormType>Ordinary</FormType>
+			<IncludeHelpInContents>false</IncludeHelpInContents>
+			<UsePurposes>
+				<v8:Value xsi:type="app:ApplicationUsePurpose">PlatformApplication</v8:Value>
+				<v8:Value xsi:type="app:ApplicationUsePurpose">MobilePlatformApplication</v8:Value>
+			</UsePurposes>
+		</Properties>
+	</Form>
+</MetaDataObject>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "1c-metadata-tree-vscode",
   "displayName": "CDT 41 (Community Development Tools for 1C)",
   "description": "Community Development Tools for 1C: visualize and edit 1C:Enterprise configuration metadata tree (EDT & Designer XML).",
-  "version": "0.49.0",
+  "version": "0.49.3",
   "icon": "images/icon.png",
   "publisher": "1c-dev",
   "repository": {

--- a/src/debug/bslDebugSession.ts
+++ b/src/debug/bslDebugSession.ts
@@ -31,6 +31,7 @@ import { BslLocalCandidate, extractLocalCandidatesFromBsl } from './bslSourceLoc
 
 const FAST_EVALUATE_WAIT_MS = 500;
 const FULL_EVALUATE_WAIT_MS = 5000;
+const MAX_SOURCE_LOCAL_EVALUATIONS = 12;
 const UNEVALUATED_LOCAL_VALUE = 'не вычислено';
 
 // ---------------------------------------------------------------------------
@@ -921,7 +922,9 @@ export class BslDebugSession extends DebugSession {
             if (state.path.length === 0 && state.sourcePath && state.sourceLine !== undefined) {
                 const source = await fs.promises.readFile(state.sourcePath, 'utf8');
                 const candidates = extractLocalCandidatesFromBsl(source, state.sourceLine);
-                response.body = { variables: buildSourceLocalVariables(candidates) };
+                response.body = {
+                    variables: await this._buildSourceLocalVariables(targetId, state.frameLevel, candidates),
+                };
                 this.sendResponse(response);
                 return;
             }
@@ -1032,6 +1035,36 @@ export class BslDebugSession extends DebugSession {
                 ? FAST_EVALUATE_WAIT_MS
                 : FULL_EVALUATE_WAIT_MS;
         return { purpose, calcWaitingTimeMs };
+    }
+
+    private async _buildSourceLocalVariables(
+        targetId: string,
+        frameLevel: number,
+        candidates: BslLocalCandidate[]
+    ): Promise<DebugProtocol.Variable[]> {
+        const variables = buildSourceLocalVariables(candidates);
+        if (!this._client) {
+            return variables;
+        }
+
+        for (let index = 0; index < Math.min(variables.length, MAX_SOURCE_LOCAL_EVALUATIONS); index += 1) {
+            const candidate = candidates[index];
+            const variable = variables[index];
+            try {
+                const result = await this._client.evaluate(targetId, candidate.name, frameLevel, {
+                    purpose: 'variables',
+                    calcWaitingTimeMs: FAST_EVALUATE_WAIT_MS,
+                });
+                if (!result.error) {
+                    variable.value = result.value;
+                    variable.type = result.typeName;
+                }
+            } catch {
+                // Keep the source-derived local visible even when the platform cannot evaluate it quickly.
+            }
+        }
+
+        return variables;
     }
 
     // -------------------------------------------------------------------------

--- a/src/debug/bslDebugSession.ts
+++ b/src/debug/bslDebugSession.ts
@@ -22,11 +22,16 @@ import {
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { RdbgClient } from './rdbg/rdbgClient';
 import { RdbgTransport } from './rdbg/rdbgTransport';
-import { RdbgRuntimeError, RdbgBreakpointRequest, RdbgCallStackItem, RdbgModuleId, RdbgExceptionBreakpointState, RdbgExceptionFilterItem, ViewInterface, SourceCalcItem, RdbgVariableNode, RdbgEvalResult } from './rdbg/rdbgTypes';
+import { RdbgRuntimeError, RdbgBreakpointRequest, RdbgCallStackItem, RdbgModuleId, RdbgExceptionBreakpointState, RdbgExceptionFilterItem, ViewInterface, SourceCalcItem, RdbgVariableNode, RdbgEvalResult, RdbgEvalOptions } from './rdbg/rdbgTypes';
 import { ReferencesTable } from './referencesTable';
 import { BslAttachConfiguration, BslLaunchConfiguration } from './types';
 import { DebuggeeLauncher, getFreePort } from './debuggeeLauncher';
 import { resolveModuleId, resolveBslPathFromRdbgModule, readExtensionName, ResolverConfigRoot } from './moduleIdResolver';
+import { BslLocalCandidate, extractLocalCandidatesFromBsl } from './bslSourceLocals';
+
+const FAST_EVALUATE_WAIT_MS = 500;
+const FULL_EVALUATE_WAIT_MS = 5000;
+const UNEVALUATED_LOCAL_VALUE = 'не вычислено';
 
 // ---------------------------------------------------------------------------
 // BpWorkspaceEntry — internal state for one BSL module's breakpoints.
@@ -44,6 +49,8 @@ interface BpWorkspaceEntry {
 interface FrameRef {
     threadId: number;
     frameLevel: number;
+    sourcePath?: string;
+    sourceLine?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -54,6 +61,8 @@ export interface VariableRef {
     frameLevel: number;
     path: SourceCalcItem[];
     view: ViewInterface;
+    sourcePath?: string;
+    sourceLine?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +111,14 @@ export function buildDapVariables(
             node.value,
             variablesReference
         ) as DebugProtocol.Variable;
+    });
+}
+
+function buildSourceLocalVariables(candidates: BslLocalCandidate[]): DebugProtocol.Variable[] {
+    return candidates.map((candidate) => {
+        const variable = new Variable(candidate.name, UNEVALUATED_LOCAL_VALUE, 0) as DebugProtocol.Variable;
+        variable.evaluateName = candidate.name;
+        return variable;
     });
 }
 
@@ -862,6 +879,8 @@ export class BslDebugSession extends DebugSession {
             frameLevel: frameRef.frameLevel,
             path: [],
             view: 'context',
+            sourcePath: frameRef.sourcePath,
+            sourceLine: frameRef.sourceLine,
         });
         const scope = new Scope('Локальные', varRef, false);
         response.body = { scopes: [scope] };
@@ -899,6 +918,13 @@ export class BslDebugSession extends DebugSession {
 
         try {
             let children: RdbgVariableNode[];
+            if (state.path.length === 0 && state.sourcePath && state.sourceLine !== undefined) {
+                const source = await fs.promises.readFile(state.sourcePath, 'utf8');
+                const candidates = extractLocalCandidatesFromBsl(source, state.sourceLine);
+                response.body = { variables: buildSourceLocalVariables(candidates) };
+                this.sendResponse(response);
+                return;
+            }
             if (state.path.length === 0 && this._isWebServer) {
                 // ibsrv crashes on evalLocalVariables — skip locals enumeration.
                 // Individual expressions work via evaluateRequest (evalExpr).
@@ -969,7 +995,12 @@ export class BslDebugSession extends DebugSession {
             let result: RdbgEvalResult | undefined =
                 watchCacheKey !== undefined ? this._watchEvaluateCache.get(watchCacheKey) : undefined;
             if (result === undefined) {
-                result = await this._client.evaluate(targetId, args.expression, frameLevel);
+                result = await this._client.evaluate(
+                    targetId,
+                    args.expression,
+                    frameLevel,
+                    this._evaluateOptionsForContext(args.context)
+                );
                 if (watchCacheKey !== undefined && !result.error) {
                     this._watchEvaluateCache.set(watchCacheKey, result);
                 }
@@ -992,6 +1023,15 @@ export class BslDebugSession extends DebugSession {
         }
 
         this.sendResponse(response);
+    }
+
+    private _evaluateOptionsForContext(context: DebugProtocol.EvaluateArguments['context']): RdbgEvalOptions {
+        const purpose = context ?? 'repl';
+        const calcWaitingTimeMs =
+            purpose === 'watch' || purpose === 'hover'
+                ? FAST_EVALUATE_WAIT_MS
+                : FULL_EVALUATE_WAIT_MS;
+        return { purpose, calcWaitingTimeMs };
     }
 
     // -------------------------------------------------------------------------
@@ -1155,7 +1195,12 @@ export class BslDebugSession extends DebugSession {
                 ? new Source(sourceName, resolvedPath)
                 : new Source(label);
             // Phase 4: use ReferencesTable for frameId (1-based, monotonic, thread-aware)
-            const frameId = this._frameRefs.add({ threadId, frameLevel: index });
+            const frameId = this._frameRefs.add({
+                threadId,
+                frameLevel: index,
+                sourcePath: resolvedPath,
+                sourceLine: item.lineNo,
+            });
             out.push(new StackFrame(frameId, label, source, item.lineNo));
         }
         return out;

--- a/src/debug/bslSourceLocals.ts
+++ b/src/debug/bslSourceLocals.ts
@@ -1,0 +1,165 @@
+export type BslLocalCandidateOrigin = 'parameter' | 'moduleVariable' | 'assignment';
+
+export interface BslLocalCandidate {
+    name: string;
+    origin: BslLocalCandidateOrigin;
+}
+
+interface RoutineRange {
+    startLine: number;
+    endLine: number;
+    params: string;
+}
+
+const IDENTIFIER = '[A-Za-zА-Яа-яЁё_][A-Za-zА-Яа-яЁё0-9_]*';
+const DECL_RE = new RegExp(`^\\s*(?:Процедура|Функция|Procedure|Function)\\s+(${IDENTIFIER})\\s*\\((.*)\\)`, 'i');
+const END_RE = /^\s*(?:КонецПроцедуры|КонецФункции|EndProcedure|EndFunction)\b/i;
+const MODULE_VAR_RE = /^\s*(?:Перем|Var)\s+(.+?)(?:;|$)/i;
+const ASSIGNMENT_RE = new RegExp(`^\\s*(${IDENTIFIER})\\s*=`);
+const FOR_RE = new RegExp(`^\\s*(?:Для|For)\\s+(${IDENTIFIER})\\s*=`, 'i');
+const FOR_EACH_RE = new RegExp(`^\\s*(?:Для\\s+Каждого|For\\s+Each)\\s+(${IDENTIFIER})\\s+(?:Из|In)(?:\\s|$)`, 'i');
+const PARAM_PREFIX_RE = /^(?:Знач|Val|ByVal)\s+/i;
+
+const KEYWORDS = new Set([
+    'Если',
+    'ИначеЕсли',
+    'Иначе',
+    'Для',
+    'Каждого',
+    'Пока',
+    'Попытка',
+    'Исключение',
+    'Возврат',
+    'Процедура',
+    'Функция',
+    'Перем',
+    'If',
+    'ElsIf',
+    'Else',
+    'For',
+    'Each',
+    'While',
+    'Try',
+    'Except',
+    'Return',
+    'Procedure',
+    'Function',
+    'Var',
+]);
+
+export function extractLocalCandidatesFromBsl(source: string, currentLine: number): BslLocalCandidate[] {
+    const lines = source.split(/\r?\n/);
+    const safeLine = Math.max(1, Math.min(currentLine, lines.length));
+    const stripped = lines.map(stripStringsAndComments);
+    const routine = findRoutineRange(stripped, safeLine);
+    const candidates: BslLocalCandidate[] = [];
+    const seen = new Set<string>();
+
+    const add = (name: string, origin: BslLocalCandidateOrigin): void => {
+        const normalized = normalizeIdentifier(name);
+        if (!normalized || KEYWORDS.has(normalized) || seen.has(normalized.toLowerCase())) {
+            return;
+        }
+        seen.add(normalized.toLowerCase());
+        candidates.push({ name: normalized, origin });
+    };
+
+    if (routine) {
+        for (const param of parseParameters(routine.params)) {
+            add(param, 'parameter');
+        }
+    }
+
+    const moduleVariableEnd = routine ? routine.startLine - 1 : safeLine;
+    for (let lineNo = 1; lineNo <= moduleVariableEnd; lineNo++) {
+        const line = stripped[lineNo - 1];
+        const match = MODULE_VAR_RE.exec(line);
+        if (!match) {
+            continue;
+        }
+        for (const name of match[1].split(',')) {
+            add(name, 'moduleVariable');
+        }
+    }
+
+    const scanStart = routine ? routine.startLine + 1 : 1;
+    for (let lineNo = scanStart; lineNo <= safeLine; lineNo++) {
+        const line = stripped[lineNo - 1];
+        const forEachMatch = FOR_EACH_RE.exec(line);
+        if (forEachMatch) {
+            add(forEachMatch[1], 'assignment');
+        }
+        const forMatch = FOR_RE.exec(line);
+        if (forMatch) {
+            add(forMatch[1], 'assignment');
+        }
+        const assignmentMatch = ASSIGNMENT_RE.exec(line);
+        if (assignmentMatch) {
+            add(assignmentMatch[1], 'assignment');
+        }
+    }
+
+    return candidates;
+}
+
+function findRoutineRange(lines: string[], currentLine: number): RoutineRange | undefined {
+    let active: RoutineRange | undefined;
+    for (let i = 0; i < lines.length; i++) {
+        const lineNo = i + 1;
+        const decl = DECL_RE.exec(lines[i]);
+        if (decl) {
+            active = { startLine: lineNo, endLine: Number.MAX_SAFE_INTEGER, params: decl[2] };
+        } else if (active && END_RE.test(lines[i])) {
+            active.endLine = lineNo;
+            if (currentLine >= active.startLine && currentLine <= active.endLine) {
+                return active;
+            }
+            active = undefined;
+        }
+
+        if (lineNo >= currentLine && active) {
+            return active;
+        }
+    }
+    return active && currentLine >= active.startLine ? active : undefined;
+}
+
+function parseParameters(params: string): string[] {
+    if (params.trim() === '') {
+        return [];
+    }
+    return params
+        .split(',')
+        .map((raw) => raw.split('=')[0].trim().replace(PARAM_PREFIX_RE, '').trim())
+        .filter((name) => name.length > 0);
+}
+
+function normalizeIdentifier(raw: string): string {
+    const trimmed = raw.trim().replace(PARAM_PREFIX_RE, '').trim();
+    const match = new RegExp(`^(${IDENTIFIER})`).exec(trimmed);
+    return match ? match[1] : '';
+}
+
+function stripStringsAndComments(line: string): string {
+    let result = '';
+    let inString = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        const next = line[i + 1];
+        if (!inString && ch === '/' && next === '/') {
+            break;
+        }
+        if (ch === '"') {
+            if (inString && next === '"') {
+                result += '  ';
+                i++;
+                continue;
+            }
+            inString = !inString;
+            result += ' ';
+            continue;
+        }
+        result += inString ? ' ' : ch;
+    }
+    return result;
+}

--- a/src/debug/rdbg/rdbgClient.ts
+++ b/src/debug/rdbg/rdbgClient.ts
@@ -16,6 +16,7 @@ import {
     RdbgBreakpoint,
     RdbgCallStackItem,
     RdbgVariable,
+    RdbgEvalOptions,
     RdbgEvalResult,
     RdbgExceptionBreakpointState,
     ViewInterface,
@@ -33,6 +34,14 @@ import {
     RdbgBreakpointCorrectedEvent,
     RdbgExpressionEvaluatedEvent,
 } from './rdbgEvents';
+
+function describeExpressionPath(path: SourceCalcItem[]): string {
+    const firstExpression = path.find((item) => item.type === 'expression');
+    if (!firstExpression || firstExpression.type !== 'expression') {
+        return '<path>';
+    }
+    return firstExpression.expression.replace(/\s+/g, ' ').slice(0, 80);
+}
 
 // ---------------------------------------------------------------------------
 // State machine type
@@ -301,14 +310,19 @@ export class RdbgClient extends EventEmitter {
         targetId: string,
         frameLevel: number,
         path: SourceCalcItem[],
-        view: ViewInterface
+        view: ViewInterface,
+        options?: RdbgEvalOptions
     ): Promise<DecodedEvalResult> {
         this.requireAttached('evalExpressionPath');
         const body = codec.encodeEvalExpressionPath(
-            this.debugUiId, targetId, frameLevel, path, view, this._infobaseAlias
+            this.debugUiId, targetId, frameLevel, path, view, this._infobaseAlias, options
         );
-        this.emit('log', `[evalExpressionPath] path=${path.length} view=${view} target=${targetId} frame=${frameLevel}`);
+        const started = Date.now();
+        const wait = options?.calcWaitingTimeMs ?? 5000;
+        const expressionLabel = describeExpressionPath(path);
+        this.emit('log', `[evalExpressionPath] purpose=${options?.purpose ?? 'unknown'} wait=${wait} path=${path.length} expr=${expressionLabel} view=${view} target=${targetId} frame=${frameLevel}`);
         const xml = await this.transport.send('evalExpr', body);
+        this.emit('log', `[evalExpressionPath] purpose=${options?.purpose ?? 'unknown'} duration=${Date.now() - started}ms path=${path.length} expr=${expressionLabel}`);
         return codec.decodeEvalResultExpanded(xml);
     }
 
@@ -330,14 +344,16 @@ export class RdbgClient extends EventEmitter {
     async evaluate(
         targetId: string,
         expression: string,
-        frameIndex: number
+        frameIndex: number,
+        options?: RdbgEvalOptions
     ): Promise<RdbgEvalResult> {
         this.requireAttached('evaluate');
         const result = await this.evalExpressionPath(
             targetId,
             frameIndex,
             [{ type: 'expression', expression }],
-            'context'
+            'context',
+            options
         );
         return result.root;
     }

--- a/src/debug/rdbg/rdbgTypes.ts
+++ b/src/debug/rdbg/rdbgTypes.ts
@@ -71,6 +71,13 @@ export interface RdbgEvalResult {
   error?: string;
 }
 
+export interface RdbgEvalOptions {
+  /** Server-side expression calculation wait in milliseconds. */
+  calcWaitingTimeMs?: number;
+  /** Diagnostic purpose propagated from DAP evaluate context. */
+  purpose?: 'watch' | 'hover' | 'repl' | 'clipboard' | 'variables' | string;
+}
+
 /**
  * View interface for path-based expression evaluation.
  * Maps to ViewInterface enum in Messages.cs (namespace debugCalculations).

--- a/src/debug/rdbg/rdbgXmlCodec.ts
+++ b/src/debug/rdbg/rdbgXmlCodec.ts
@@ -473,9 +473,11 @@ export function encodeEvalExpressionPath(
   frameLevel: number,
   path: SourceCalcItem[],
   _view: ViewInterface,
-  infobaseAlias?: string
+  infobaseAlias?: string,
+  options?: { calcWaitingTimeMs?: number }
 ): string {
   const alias = infobaseAlias ?? DEF_ALIAS;
+  const calcWaitingTime = normalizeCalcWaitingTime(options?.calcWaitingTimeMs);
 
   // Build calcItem elements for each step in the path
   let calcItems = '';
@@ -503,7 +505,7 @@ export function encodeEvalExpressionPath(
   const fields =
     `  <${P_RDBG}:infoBaseAlias>${escapeXml(alias)}</${P_RDBG}:infoBaseAlias>\n` +
     `  <${P_RDBG}:idOfDebuggerUI>${escapeXml(debugUiId)}</${P_RDBG}:idOfDebuggerUI>\n` +
-    `  <${P_RDBG}:calcWaitingTime>5000</${P_RDBG}:calcWaitingTime>\n` +
+    `  <${P_RDBG}:calcWaitingTime>${calcWaitingTime}</${P_RDBG}:calcWaitingTime>\n` +
     targetIdToXml(targetId, '  ') +
     `  <${P_RDBG}:expr>\n` +
     `    <${P_CALC}:stackLevel>${frameLevel}</${P_CALC}:stackLevel>\n` +
@@ -512,6 +514,13 @@ export function encodeEvalExpressionPath(
       : '') +
     `  </${P_RDBG}:expr>\n`;
   return wrapRequest(fields);
+}
+
+function normalizeCalcWaitingTime(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 5000;
+  }
+  return Math.max(0, Math.min(5000, Math.trunc(value)));
 }
 
 /**
@@ -526,7 +535,8 @@ export function encodeEvaluate(
   _seanceId: string,
   expression: string,
   frameIndex: number,
-  infobaseAlias?: string
+  infobaseAlias?: string,
+  options?: { calcWaitingTimeMs?: number }
 ): string {
   return encodeEvalExpressionPath(
     debugUiId,
@@ -534,7 +544,8 @@ export function encodeEvaluate(
     frameIndex,
     [{ type: 'expression', expression }],
     'context',
-    infobaseAlias
+    infobaseAlias,
+    options
   );
 }
 

--- a/src/parsers/designerParser.ts
+++ b/src/parsers/designerParser.ts
@@ -219,13 +219,14 @@ export class DesignerParser {
     }
 
     const names = new Set<string>([...directoryNames, ...flatXmlNames]);
-    return Array.from(names)
-      .sort((a, b) => a.localeCompare(b, 'ru', { sensitivity: 'base' }))
-      .map((name) => {
+    const sortedNames = Array.from(names)
+      .sort((a, b) => a.localeCompare(b, 'ru', { sensitivity: 'base' }));
+
+    return Promise.all(sortedNames.map(async (name) => {
         const flatXmlPath = path.join(typePath, `${name}.xml`);
         const directoryPath = path.join(typePath, name);
         const filePath = flatXmlNames.has(name) ? flatXmlPath : directoryPath;
-        return {
+        const node: TreeNode = {
           id: `${typeName}.${name}`,
           name,
           type: metadataType,
@@ -233,7 +234,17 @@ export class DesignerParser {
           children: [],
           filePath,
         };
-      });
+        if (STANDARD_MODULES[metadataType] !== undefined) {
+          const extNode = await this.parseExtensions(
+            path.join(directoryPath, 'Ext'),
+            typeName === 'CommonModules' ? `${typeName}.${name}` : undefined,
+            metadataType
+          );
+          extNode.parent = node;
+          node.children = [extNode];
+        }
+        return node;
+      }));
   }
 
   /**

--- a/test/suite/bslDebugSessionWatchCache.test.ts
+++ b/test/suite/bslDebugSessionWatchCache.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { DebugProtocol } from '@vscode/debugprotocol';
 
 import { BslDebugSession } from '../../src/debug/bslDebugSession';
-import { RdbgEvalResult } from '../../src/debug/rdbg/rdbgTypes';
+import { RdbgEvalOptions, RdbgEvalResult } from '../../src/debug/rdbg/rdbgTypes';
 
 class TestBslDebugSession extends BslDebugSession {
   public readonly responses: DebugProtocol.EvaluateResponse[] = [];
@@ -85,5 +85,45 @@ suite('BslDebugSession - watch evaluate cache', () => {
     assert.strictEqual(evaluateCalls, 2);
     assert.strictEqual(session.responses[0].body?.result, 'Сумма:1');
     assert.strictEqual(session.responses[1].body?.result, 'Сумма:2');
+  });
+  test('watch and hover use short calcWaitingTime while repl keeps the long wait', async () => {
+    const session = new TestBslDebugSession();
+    const calls: Array<{ purpose: string | undefined; options: RdbgEvalOptions | undefined }> = [];
+    const fakeClient = {
+      async evaluate(
+        _targetId: string,
+        _expression: string,
+        _frameLevel: number,
+        options?: RdbgEvalOptions
+      ): Promise<RdbgEvalResult> {
+        calls.push({ purpose: options?.purpose, options });
+        return {
+          value: 'ok',
+          typeName: 'Boolean',
+          isExpandable: false,
+        };
+      },
+    };
+
+    const internals = session as unknown as {
+      _client: unknown;
+      _pausedThreadId: number;
+      _threadMap: Map<number, string>;
+    };
+    internals._client = fakeClient;
+    internals._pausedThreadId = 1;
+    internals._threadMap.set(1, 'target-1');
+
+    await session.evaluateForTest({ expression: 'A', context: 'watch' });
+    await session.evaluateForTest({ expression: 'B', context: 'hover' });
+    await session.evaluateForTest({ expression: 'C', context: 'repl' });
+
+    assert.strictEqual(calls.length, 3);
+    assert.strictEqual(calls[0].purpose, 'watch');
+    assert.strictEqual(calls[0].options?.calcWaitingTimeMs, 500);
+    assert.strictEqual(calls[1].purpose, 'hover');
+    assert.strictEqual(calls[1].options?.calcWaitingTimeMs, 500);
+    assert.strictEqual(calls[2].purpose, 'repl');
+    assert.strictEqual(calls[2].options?.calcWaitingTimeMs, 5000);
   });
 });

--- a/test/suite/bslSourceLocals.test.ts
+++ b/test/suite/bslSourceLocals.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DebugProtocol } from '@vscode/debugprotocol';
+
+import { BslDebugSession, VariableRef } from '../../src/debug/bslDebugSession';
+import { extractLocalCandidatesFromBsl } from '../../src/debug/bslSourceLocals';
+import { RdbgEvalResult } from '../../src/debug/rdbg/rdbgTypes';
+import { ReferencesTable } from '../../src/debug/referencesTable';
+
+class TestBslDebugSession extends BslDebugSession {
+  public readonly variableResponses: DebugProtocol.VariablesResponse[] = [];
+
+  public variablesForTest(variablesReference: number): Promise<void> {
+    const response = {
+      seq: 0,
+      type: 'response',
+      request_seq: 1,
+      command: 'variables',
+      success: true,
+    } as DebugProtocol.VariablesResponse;
+    return this.variablesRequest(response, { variablesReference });
+  }
+
+  public sendResponse(response: DebugProtocol.Response): void {
+    if (response.command === 'variables') {
+      this.variableResponses.push(response as DebugProtocol.VariablesResponse);
+    }
+  }
+}
+
+suite('bslSourceLocals', () => {
+  test('extracts parameters, module variables and assignments visible at the current line', () => {
+    const source = [
+      'Перем ModuleVar;',
+      '',
+      'Процедура Обработать(Знач Отказ, Параметр2 = Неопределено)',
+      '  Сумма = 1;',
+      '  Для Каждого Строка Из Таблица Цикл',
+      '    Текущий = Строка;',
+      '  КонецЦикла;',
+      'КонецПроцедуры',
+    ].join('\n');
+
+    const candidates = extractLocalCandidatesFromBsl(source, 7);
+
+    assert.deepStrictEqual(
+      candidates.map((candidate) => candidate.name),
+      ['Отказ', 'Параметр2', 'ModuleVar', 'Сумма', 'Строка', 'Текущий']
+    );
+  });
+
+  test('variablesRequest uses source-derived locals without unsafe top-level RDBG locals', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), '1cviewer-debug-locals-'));
+    const filePath = path.join(dir, 'ObjectModule.bsl');
+    fs.writeFileSync(filePath, [
+      'Процедура Обработать(Отказ)',
+      '  Сумма = 1;',
+      'КонецПроцедуры',
+    ].join('\n'), 'utf8');
+
+    const session = new TestBslDebugSession();
+    const fakeClient = {
+      async evalLocalVariables(): Promise<never> {
+        throw new Error('unsafe locals must not be called');
+      },
+      async evaluate(): Promise<RdbgEvalResult> {
+        throw new Error('bulk evaluate must not be called');
+      },
+    };
+    const internals = session as unknown as {
+      _client: unknown;
+      _threadMap: Map<number, string>;
+      _variableRefs: ReferencesTable<VariableRef>;
+    };
+    internals._client = fakeClient;
+    internals._threadMap.set(1, 'target-1');
+    const variablesReference = internals._variableRefs.add({
+      threadId: 1,
+      frameLevel: 0,
+      path: [],
+      view: 'context',
+      sourcePath: filePath,
+      sourceLine: 2,
+    } as VariableRef);
+
+    await session.variablesForTest(variablesReference);
+
+    const variables = session.variableResponses[0].body?.variables ?? [];
+    assert.deepStrictEqual(variables.map((variable) => variable.name), ['Отказ', 'Сумма']);
+    assert.ok(variables.every((variable) => variable.value === 'не вычислено'));
+    assert.ok(variables.every((variable) => variable.variablesReference === 0));
+  });
+});

--- a/test/suite/bslSourceLocals.test.ts
+++ b/test/suite/bslSourceLocals.test.ts
@@ -51,6 +51,51 @@ suite('bslSourceLocals', () => {
     );
   });
 
+  test('extracts English locals without leaking names from strings, comments or other routines', () => {
+    const source = [
+      'Var ModuleA, ModuleB;',
+      'Var For, ModuleA, Valid2;',
+      '',
+      'Function First()',
+      '  Hidden = 1;',
+      'EndFunction',
+      '',
+      'Function Second(ByVal ParamOne, ParamTwo = 42)',
+      '  Text = "Fake = 1 // ignored"; // Commented = 2',
+      '  For Each Row In Rows Do',
+      '    For Index = 1 To 2 Do',
+      '      Value = Row;',
+      '    EndDo;',
+      'EndFunction',
+    ].join('\n');
+
+    const candidates = extractLocalCandidatesFromBsl(source, 12);
+
+    assert.deepStrictEqual(
+      candidates.map((candidate) => candidate.name),
+      ['ParamOne', 'ParamTwo', 'ModuleA', 'ModuleB', 'Valid2', 'Text', 'Row', 'Index', 'Value']
+    );
+  });
+
+  test('handles empty parameter lists and out-of-range lines', () => {
+    const source = [
+      'Var ModuleOnly;',
+      '',
+      'Procedure Empty()',
+      'EndProcedure',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractLocalCandidatesFromBsl('', 100), []);
+    assert.deepStrictEqual(
+      extractLocalCandidatesFromBsl(source, 100).map((candidate) => candidate.name),
+      ['ModuleOnly']
+    );
+    assert.deepStrictEqual(
+      extractLocalCandidatesFromBsl(source, 0).map((candidate) => candidate.name),
+      ['ModuleOnly']
+    );
+  });
+
   test('variablesRequest uses source-derived locals without unsafe top-level RDBG locals', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), '1cviewer-debug-locals-'));
     const filePath = path.join(dir, 'ObjectModule.bsl');
@@ -147,5 +192,75 @@ suite('bslSourceLocals', () => {
     assert.deepStrictEqual(calls.map((call) => call.expression), ['Refusal', 'a']);
     assert.ok(calls.every((call) => call.options?.purpose === 'variables'));
     assert.ok(calls.every((call) => call.options?.calcWaitingTimeMs === 500));
+  });
+
+  test('variablesRequest limits eager local evaluation to the fast budget', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), '1cviewer-debug-local-limit-'));
+    const filePath = path.join(dir, 'ObjectModule.bsl');
+    fs.writeFileSync(filePath, [
+      'Procedure Handle()',
+      '  v01 = 1;',
+      '  v02 = 2;',
+      '  v03 = 3;',
+      '  v04 = 4;',
+      '  v05 = 5;',
+      '  v06 = 6;',
+      '  v07 = 7;',
+      '  v08 = 8;',
+      '  v09 = 9;',
+      '  v10 = 10;',
+      '  v11 = 11;',
+      '  v12 = 12;',
+      '  v13 = 13;',
+      '  v14 = 14;',
+      '  v15 = 15;',
+      'EndProcedure',
+    ].join('\n'), 'utf8');
+
+    const calls: string[] = [];
+    const session = new TestBslDebugSession();
+    const fakeClient = {
+      async evalLocalVariables(): Promise<never> {
+        throw new Error('unsafe locals must not be called');
+      },
+      async evaluate(
+        _targetId: string,
+        expression: string,
+        _frameLevel: number,
+        options?: RdbgEvalOptions
+      ): Promise<RdbgEvalResult> {
+        assert.strictEqual(options?.purpose, 'variables');
+        assert.strictEqual(options?.calcWaitingTimeMs, 500);
+        calls.push(expression);
+        return {
+          value: expression.toUpperCase(),
+          typeName: 'String',
+          isExpandable: false,
+        };
+      },
+    };
+    const internals = session as unknown as {
+      _client: unknown;
+      _threadMap: Map<number, string>;
+      _variableRefs: ReferencesTable<VariableRef>;
+    };
+    internals._client = fakeClient;
+    internals._threadMap.set(1, 'target-1');
+    const variablesReference = internals._variableRefs.add({
+      threadId: 1,
+      frameLevel: 0,
+      path: [],
+      view: 'context',
+      sourcePath: filePath,
+      sourceLine: 16,
+    } as VariableRef);
+
+    await session.variablesForTest(variablesReference);
+
+    const variables = session.variableResponses[0].body?.variables ?? [];
+    assert.strictEqual(calls.length, 12);
+    assert.deepStrictEqual(calls, ['v01', 'v02', 'v03', 'v04', 'v05', 'v06', 'v07', 'v08', 'v09', 'v10', 'v11', 'v12']);
+    assert.deepStrictEqual(variables.slice(0, 12).map((variable) => variable.value), calls.map((name) => name.toUpperCase()));
+    assert.deepStrictEqual(variables.slice(12).map((variable) => variable.value), ['не вычислено', 'не вычислено', 'не вычислено']);
   });
 });

--- a/test/suite/bslSourceLocals.test.ts
+++ b/test/suite/bslSourceLocals.test.ts
@@ -6,7 +6,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 
 import { BslDebugSession, VariableRef } from '../../src/debug/bslDebugSession';
 import { extractLocalCandidatesFromBsl } from '../../src/debug/bslSourceLocals';
-import { RdbgEvalResult } from '../../src/debug/rdbg/rdbgTypes';
+import { RdbgEvalOptions, RdbgEvalResult } from '../../src/debug/rdbg/rdbgTypes';
 import { ReferencesTable } from '../../src/debug/referencesTable';
 
 class TestBslDebugSession extends BslDebugSession {
@@ -91,5 +91,61 @@ suite('bslSourceLocals', () => {
     assert.deepStrictEqual(variables.map((variable) => variable.name), ['Отказ', 'Сумма']);
     assert.ok(variables.every((variable) => variable.value === 'не вычислено'));
     assert.ok(variables.every((variable) => variable.variablesReference === 0));
+  });
+  test('variablesRequest evaluates source-derived locals with short per-expression eval', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), '1cviewer-debug-local-values-'));
+    const filePath = path.join(dir, 'ObjectModule.bsl');
+    fs.writeFileSync(filePath, [
+      'Procedure Handle(Refusal)',
+      '  a = 0;',
+      'EndProcedure',
+    ].join('\n'), 'utf8');
+
+    const calls: Array<{ expression: string; options: RdbgEvalOptions | undefined }> = [];
+    const session = new TestBslDebugSession();
+    const fakeClient = {
+      async evalLocalVariables(): Promise<never> {
+        throw new Error('unsafe locals must not be called');
+      },
+      async evaluate(
+        _targetId: string,
+        expression: string,
+        _frameLevel: number,
+        options?: RdbgEvalOptions
+      ): Promise<RdbgEvalResult> {
+        calls.push({ expression, options });
+        return {
+          value: expression === 'a' ? '0' : 'False',
+          typeName: expression === 'a' ? 'Number' : 'Boolean',
+          isExpandable: false,
+        };
+      },
+    };
+    const internals = session as unknown as {
+      _client: unknown;
+      _threadMap: Map<number, string>;
+      _variableRefs: ReferencesTable<VariableRef>;
+    };
+    internals._client = fakeClient;
+    internals._threadMap.set(1, 'target-1');
+    const variablesReference = internals._variableRefs.add({
+      threadId: 1,
+      frameLevel: 0,
+      path: [],
+      view: 'context',
+      sourcePath: filePath,
+      sourceLine: 2,
+    } as VariableRef);
+
+    await session.variablesForTest(variablesReference);
+
+    const variables = session.variableResponses[0].body?.variables ?? [];
+    assert.deepStrictEqual(variables.map((variable) => [variable.name, variable.value]), [
+      ['Refusal', 'False'],
+      ['a', '0'],
+    ]);
+    assert.deepStrictEqual(calls.map((call) => call.expression), ['Refusal', 'a']);
+    assert.ok(calls.every((call) => call.options?.purpose === 'variables'));
+    assert.ok(calls.every((call) => call.options?.calcWaitingTimeMs === 500));
   });
 });

--- a/test/suite/coreSuites.ts
+++ b/test/suite/coreSuites.ts
@@ -3,6 +3,7 @@ export const coreSuiteFiles: string[] = [
   'suite/designerParser.test.js',
   'suite/formatDetector.test.js',
   'suite/formEditorTitle.test.js',
+  'suite/formatSamplesIntegrity.test.js',
   'suite/treeDataProvider.test.js',
   'suite/formXmlParser.test.js',
   'suite/formXmlWriter.test.js',

--- a/test/suite/coreSuites.ts
+++ b/test/suite/coreSuites.ts
@@ -141,6 +141,7 @@ export const coreSuiteFiles: string[] = [
   'suite/rdbgXmlCodec.test.js',
   'suite/referencesTable.test.js',
   'suite/moduleIdResolver.test.js',
+  'suite/bslSourceLocals.test.js',
   'suite/bslDebugSessionWatchCache.test.js',
   'suite/rdbgClientVariables.test.js',
   'suite/bslDebugSessionBreakpoints.test.js',

--- a/test/suite/designerParser.test.ts
+++ b/test/suite/designerParser.test.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import { DesignerParser } from '../../src/parsers/designerParser';
 import { XmlParser } from '../../src/parsers/xmlParser';
 import { MetadataType, TreeNode } from '../../src/models/treeNode';
+import { STANDARD_MODULES } from '../../src/constants/moduleTypes';
+import { MetadataTypeMapper } from '../../src/utils/metadataTypeMapper';
 import {
   ensureTabularSectionColumnsPlaceholder,
   isTabularSectionColumnsContainer,
@@ -189,7 +191,10 @@ suite('DesignerParser', () => {
     const catalogsPath = path.join(configPath, 'Catalogs');
     const originalParseFileAsync = XmlParser.parseFileAsync;
     await fs.promises.mkdir(path.join(catalogsPath, 'FolderCatalog'), { recursive: true });
+    await fs.promises.mkdir(path.join(catalogsPath, 'FolderCatalog', 'Ext'), { recursive: true });
     await fs.promises.writeFile(path.join(catalogsPath, 'FolderCatalog.xml'), '<MetaDataObject/>', 'utf-8');
+    await fs.promises.writeFile(path.join(catalogsPath, 'FolderCatalog', 'Ext', 'ObjectModule.bsl'), '', 'utf-8');
+    await fs.promises.writeFile(path.join(catalogsPath, 'FolderCatalog', 'Ext', 'ManagerModule.bsl'), '', 'utf-8');
     await fs.promises.writeFile(path.join(catalogsPath, 'FlatCatalog.xml'), '<broken>', 'utf-8');
     await fs.promises.writeFile(path.join(catalogsPath, 'readme.txt'), 'skip', 'utf-8');
 
@@ -203,7 +208,53 @@ suite('DesignerParser', () => {
 
       assert.deepStrictEqual(names, ['FlatCatalog', 'FolderCatalog']);
       assert.ok(children.every((c) => c.properties._lazy === true));
-      assert.ok(children.every((c) => c.children?.length === 0));
+      const folderCatalog = children.find((c) => c.name === 'FolderCatalog');
+      assert.ok(folderCatalog, 'FolderCatalog should be listed');
+      const ext = folderCatalog.children?.find((c) => c.id === 'Ext');
+      assert.ok(ext, 'parseTypeIndex should preserve Ext/modules for shallow object nodes');
+      assert.deepStrictEqual(
+        ext.children?.map((c) => c.name).sort(),
+        ['ManagerModule.bsl', 'ObjectModule.bsl']
+      );
+    } finally {
+      XmlParser.parseFileAsync = originalParseFileAsync;
+      await fs.promises.rm(configPath, { recursive: true, force: true });
+    }
+  });
+
+  test('parseTypeIndex preserves standard module nodes for all module-bearing metadata types', async () => {
+    const configPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), '1cviewer-type-index-modules-'));
+    const originalParseFileAsync = XmlParser.parseFileAsync;
+    try {
+      (XmlParser.parseFileAsync as unknown as typeof XmlParser.parseFileAsync) = async () => {
+        throw new Error('parseTypeIndex must not parse object XML');
+      };
+
+      for (const [metadataType, modules] of Object.entries(STANDARD_MODULES)) {
+        if (metadataType === MetadataType.Configuration) {
+          continue;
+        }
+        const folderId = MetadataTypeMapper.getDesignerFolderIdForMetadataType(metadataType as MetadataType);
+        assert.ok(folderId, `folderId must exist for ${metadataType}`);
+        const typePath = path.join(configPath, folderId);
+        const objectName = `${folderId}Object`;
+        await fs.promises.mkdir(path.join(typePath, objectName, 'Ext'), { recursive: true });
+        await fs.promises.writeFile(path.join(typePath, `${objectName}.xml`), '<MetaDataObject/>', 'utf-8');
+        for (const mod of modules) {
+          await fs.promises.writeFile(path.join(typePath, objectName, 'Ext', mod.fileName), '', 'utf-8');
+        }
+
+        const children = await DesignerParser.parseTypeIndex(configPath, folderId);
+        const node = children.find((c) => c.name === objectName);
+        assert.ok(node, `${folderId}: object should be indexed`);
+        const ext = node.children?.find((c) => c.name === 'Extensions');
+        assert.ok(ext, `${folderId}: Extensions node should be preserved`);
+        assert.deepStrictEqual(
+          ext.children?.map((c) => c.name).sort(),
+          modules.map((m) => m.fileName).sort(),
+          `${folderId}: standard module list should match`
+        );
+      }
     } finally {
       XmlParser.parseFileAsync = originalParseFileAsync;
       await fs.promises.rm(configPath, { recursive: true, force: true });

--- a/test/suite/formatSamplesIntegrity.test.ts
+++ b/test/suite/formatSamplesIntegrity.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function walkXmlFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const result: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...walkXmlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.xml')) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+suite('FormatSamples integrity', () => {
+  test('empty_conf has no dangling form child references', () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const configRoot = path.join(repoRoot, 'FormatSamples', 'empty_conf');
+    const missing: string[] = [];
+
+    for (const xmlPath of walkXmlFiles(configRoot)) {
+      const xml = fs.readFileSync(xmlPath, 'utf8');
+      const objectDir = path.join(path.dirname(xmlPath), path.basename(xmlPath, '.xml'));
+      for (const match of xml.matchAll(/<Form>([^<]+)<\/Form>/g)) {
+        const formName = match[1];
+        const formPath = path.join(objectDir, 'Forms', `${formName}.xml`);
+        if (!fs.existsSync(formPath)) {
+          missing.push(path.relative(repoRoot, formPath));
+        }
+      }
+    }
+
+    assert.deepStrictEqual(missing, []);
+  });
+});

--- a/test/suite/rdbgXmlCodec.test.ts
+++ b/test/suite/rdbgXmlCodec.test.ts
@@ -757,6 +757,20 @@ suite('rdbgXmlCodec — Phase 4 encodeEvalExpressionPath', () => {
       assert.ok(xml.includes(':stackLevel>3<'), 'stackLevel=3 present');
     });
 
+    test('custom calcWaitingTime is emitted for fast interactive evaluation', () => {
+      const xml = encodeEvalExpressionPath(
+        DBG_UI_ID,
+        TARGET_ID,
+        0,
+        [{ type: 'expression', expression: 'x' }],
+        'context',
+        undefined,
+        { calcWaitingTimeMs: 500 }
+      );
+      assert.ok(xml.includes(':calcWaitingTime>500<'), 'calcWaitingTime=500 present');
+      assert.ok(!xml.includes(':calcWaitingTime>5000<'), 'default calcWaitingTime absent');
+    });
+
     test('property step uses itemType=property and <property> element', () => {
       const xml = encodeEvalExpressionPath(DBG_UI_ID, TARGET_ID, 0, [{ type: 'property', property: 'МоёПоле' }], 'context');
       assert.ok(xml.includes('>property<'), 'itemType=property');


### PR DESCRIPTION
## Что сделано
- Ускорены watch/hover выражения отладчика: короткий `calcWaitingTime=500` и кеш watch на текущей остановке.
- Локальные переменные в Variables теперь берутся из исходника и безопасно пересчитываются индивидуальными короткими eval-запросами без `evalLocalVariables`.
- Восстановлены стандартные модули объектов в дереве после ускоренного `parseTypeIndex`.
- Починена целостность `FormatSamples/empty_conf`: восстановлен отсутствующий XML формы, добавлен тест на висячие ссылки форм.
- Собран VSIX `0.49.4`.

## Связанные issue
Refs #93
Refs #94

## Проверки
- `npx tsc -p tsconfig.test.json`
- `node node_modules/mocha/bin/mocha --ui tdd out/test/suite/bslDebugSessionWatchCache.test.js out/test/suite/bslSourceLocals.test.js out/test/suite/rdbgXmlCodec.test.js out/test/suite/rdbgClientVariables.test.js`
- `node node_modules/mocha/bin/mocha --ui tdd out/test/suite/formatSamplesIntegrity.test.js`
- `npm run compile`
- `npm run lint`
- `npm run lint:test-promises`
- `npm run test:coverage` — 2663 passing, 35 pending
- `npm run coverage:check`
- `build-all.bat` — собран `releases/1c-metadata-tree-vscode-0.49.4.vsix`