### PR TITLE
Не показывать warning без конфигурации 1С

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -4,7 +4,6 @@
 export const MESSAGES = {
   // Workspace messages
   NO_WORKSPACE: 'Откройте папку с конфигурацией 1С',
-  NO_CONFIGURATION: 'Конфигурация 1С не найдена в рабочей области',
 
   // Empty states (req.10)
   EMPTY_STATE_NO_SELECTION_TITLE: 'Ничего не выбрано.',

--- a/src/extension/metadataTreeLifecycle.ts
+++ b/src/extension/metadataTreeLifecycle.ts
@@ -89,7 +89,6 @@ export function createMetadataTreeLifecycle(state: ExtensionState): MetadataTree
     const configs = await FormatDetector.findAllConfigurationRoots(workspacePaths);
     const packages = await FormatDetector.findAllConfigurationPackageFiles(workspacePaths);
     if (configs.length === 0 && packages.length === 0) {
-      vscode.window.showWarningMessage(MESSAGES.NO_CONFIGURATION);
       state.treeDataProvider.setRootNodes([], undefined);
       return;
     }

--- a/test/suite/coreSuites.ts
+++ b/test/suite/coreSuites.ts
@@ -9,6 +9,7 @@ export const coreSuiteFiles: string[] = [
   'suite/formXmlWriter.test.js',
   'suite/metadataParser.test.js',
   'suite/metadataParser.edge.test.js',
+  'suite/metadataTreeLifecycle.test.js',
   'suite/typeContentsCache.test.js',
   'suite/metadataDefaultValues.test.js',
   'suite/metadataFileLocator.test.js',

--- a/test/suite/metadataTreeLifecycle.test.ts
+++ b/test/suite/metadataTreeLifecycle.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { MESSAGES } from '../../src/constants/messages';
+import { createMetadataTreeLifecycle } from '../../src/extension/metadataTreeLifecycle';
+import { MetadataType, TreeNode } from '../../src/models/treeNode';
+import { FormatDetector } from '../../src/parsers/formatDetector';
+import { MetadataTreeDataProvider } from '../../src/providers/treeDataProvider';
+import { ExtensionState } from '../../src/state/extensionState';
+import {
+  resetVscodeTestState,
+  vscodeTestState,
+} from '../helpers/vscodeModuleStub';
+
+suite('MetadataTreeLifecycle', () => {
+  const originalFindAllConfigurationRoots = FormatDetector.findAllConfigurationRoots;
+  const originalFindAllConfigurationPackageFiles = FormatDetector.findAllConfigurationPackageFiles;
+
+  function stubDiscovery(options?: {
+    configs?: Array<{ configPath: string; workspaceFolderPath: string }>;
+    packages?: Array<{ filePath: string; workspaceFolderPath: string }>;
+  }): void {
+    (FormatDetector.findAllConfigurationRoots as unknown as typeof FormatDetector.findAllConfigurationRoots) =
+      async () => options?.configs ?? [];
+    (FormatDetector.findAllConfigurationPackageFiles as unknown as typeof FormatDetector.findAllConfigurationPackageFiles) =
+      async () => options?.packages ?? [];
+  }
+
+  function createStateWithProvider(): {
+    state: ExtensionState;
+    provider: MetadataTreeDataProvider;
+    messages: Array<string | undefined>;
+  } {
+    const state = new ExtensionState();
+    const provider = new MetadataTreeDataProvider();
+    const messages: Array<string | undefined> = [];
+    provider.setMessageUpdater((message) => messages.push(message));
+    state.treeDataProvider = provider;
+    return { state, provider, messages };
+  }
+
+  setup(() => {
+    resetVscodeTestState();
+    stubDiscovery();
+  });
+
+  teardown(() => {
+    (FormatDetector.findAllConfigurationRoots as unknown as typeof FormatDetector.findAllConfigurationRoots) =
+      originalFindAllConfigurationRoots;
+    (FormatDetector.findAllConfigurationPackageFiles as unknown as typeof FormatDetector.findAllConfigurationPackageFiles) =
+      originalFindAllConfigurationPackageFiles;
+    resetVscodeTestState();
+  });
+
+  test('no configuration clears roots and uses contextual empty state without a global warning', async () => {
+    vscodeTestState.mockWorkspaceFolders = [
+      { name: 'non-1c', index: 0, uri: vscode.Uri.file('C:/workspace/non-1c') },
+    ];
+    const { state, provider, messages } = createStateWithProvider();
+    const existingRoot: TreeNode = {
+      id: 'existing-configuration',
+      name: 'Configuration',
+      type: MetadataType.Configuration,
+      properties: {},
+    };
+    provider.setRootNode(existingRoot);
+
+    await createMetadataTreeLifecycle(state).loadMetadataTree();
+
+    assert.deepStrictEqual(vscodeTestState.warningLog, []);
+    assert.deepStrictEqual(provider.getRootNodes(), []);
+    assert.strictEqual(messages.at(-1), MESSAGES.EMPTY_TREE_MESSAGE);
+  });
+
+  test('no workspace preserves NO_WORKSPACE warning and clears the tree', async () => {
+    vscodeTestState.mockWorkspaceFolders = [];
+    const { state, provider, messages } = createStateWithProvider();
+
+    await createMetadataTreeLifecycle(state).loadMetadataTree();
+
+    assert.deepStrictEqual(vscodeTestState.warningLog, [MESSAGES.NO_WORKSPACE]);
+    assert.deepStrictEqual(provider.getRootNodes(), []);
+    assert.strictEqual(messages.at(-1), MESSAGES.EMPTY_TREE_MESSAGE);
+  });
+
+  test('a real metadata load error is still reported', async () => {
+    const workspaceFolderPath = 'C:/workspace/1c';
+    vscodeTestState.mockWorkspaceFolders = [
+      { name: '1c', index: 0, uri: vscode.Uri.file(workspaceFolderPath) },
+    ];
+    stubDiscovery({
+      configs: [{ configPath: 'C:/missing-configuration', workspaceFolderPath }],
+    });
+    const { state } = createStateWithProvider();
+
+    await createMetadataTreeLifecycle(state).loadMetadataTree();
+
+    assert.strictEqual(vscodeTestState.warningLog.length, 0);
+    assert.strictEqual(vscodeTestState.errorLog.length, 1);
+    assert.match(vscodeTestState.errorLog[0], new RegExp(`^${MESSAGES.ERROR_LOADING}:`));
+  });
+});


### PR DESCRIPTION
## Что изменено

- удалён глобальный warning при пустом результате поиска XML-конфигураций и пакетов `.cf`/`.cfe`;
- сохранена очистка дерева и существующее contextual empty-state внутри CDT 41 TreeView;
- удалена неиспользуемая константа сообщения;
- добавлены lifecycle-регрессии на пустой workspace, отсутствие workspace и реальную ошибку загрузки.

## Почему

Расширение активируется через `onStartupFinished`, поэтому раньше любой обычный не-1С проект получал предупреждающий toast. Отсутствие конфигурации является допустимым состоянием, а TreeView уже содержит достаточную подсказку.

## Проверка

- `test-suite.bat` — 2869 passing, 35 pending;
- `npm run compile` — успешно;
- `npx tsc --noEmit` — успешно;
- `smoke-tests.bat` — 10 passing, 1 pending, exit 0;
- `git diff --check` — чисто.

Closes #109