### PR TITLE
fix: auto-detect ibcmd Cyrillic output encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1256,7 +1256,7 @@
             "oem866",
             "windows1251"
           ],
-          "description": "How to decode ibcmd stdout/stderr for the Infobase output channel. \"auto\" uses UTF-8 streaming (typical piped ibcmd [INFO] lines). If text is garbled, try \"oem866\" (legacy Russian console) or \"windows1251\". For UTF-16 LE output, use \"utf16le\"."
+          "description": "How to decode ibcmd stdout/stderr for the Infobase output channel. \"auto\" detects UTF-8, OEM866, and Windows-1251 output. Manual modes remain available for unusual output; use \"utf16le\" for UTF-16 LE."
         },
         "1cMetadataTree.ibcmd.importDiagnostics": {
           "type": "boolean",

--- a/src/services/ibcmd/consoleStreamDecoder.ts
+++ b/src/services/ibcmd/consoleStreamDecoder.ts
@@ -1,6 +1,22 @@
 import iconv from 'iconv-lite';
 import type { IbcmdConsoleOutputEncoding } from './ibcmdConsoleEncodingTypes';
 
+type LegacyCyrillicEncoding = 'cp866' | 'cp1251';
+
+function russianLetterCount(text: string): number {
+  return text.match(/[А-Яа-яЁё]/gu)?.length ?? 0;
+}
+
+/**
+ * Chooses the legacy Cyrillic code page whose decoded text contains more Russian letters.
+ * CP866 wins ties because ibcmd is a console application and commonly writes through the OEM code page.
+ */
+export function detectLegacyCyrillicEncoding(raw: Buffer): LegacyCyrillicEncoding {
+  const cp866Score = russianLetterCount(iconv.decode(raw, 'cp866'));
+  const cp1251Score = russianLetterCount(iconv.decode(raw, 'cp1251'));
+  return cp866Score >= cp1251Score ? 'cp866' : 'cp1251';
+}
+
 function isValidUtf8Buffer(buf: Buffer): boolean {
   if (buf.length === 0) {
     return true;
@@ -74,7 +90,7 @@ export function isLikelyUtf8(buf: Buffer): boolean {
 }
 
 /**
- * Full-buffer heuristic: prefer UTF-8 when the byte sequence is valid UTF-8; on Windows otherwise use CP866 (typical console).
+ * Full-buffer heuristic: prefer UTF-8 when the byte sequence is valid UTF-8; on Windows otherwise detect CP866 / CP1251.
  */
 export function decodeConsoleStreamAuto(raw: Buffer): string {
   if (raw.length === 0) {
@@ -84,7 +100,7 @@ export function decodeConsoleStreamAuto(raw: Buffer): string {
     return raw.toString('utf8');
   }
   if (process.platform === 'win32') {
-    return iconv.decode(raw, 'cp866');
+    return iconv.decode(raw, detectLegacyCyrillicEncoding(raw));
   }
   return raw.toString('utf8');
 }
@@ -133,7 +149,7 @@ export interface IbcmdStreamChunkDecoders {
  *
  * `auto` mode detects encoding on the first chunk containing non-ASCII bytes (≥ 0x80).
  * If that chunk is valid UTF-8, all subsequent chunks are decoded as UTF-8 streaming.
- * Otherwise the fallback encoding is CP1251 on Windows or CP866 on other platforms.
+ * Otherwise CP866 and CP1251 are scored by how many Russian letters they produce.
  * If no non-ASCII bytes appear before the stream ends, UTF-8 is used throughout.
  *
  * The encoding decision is shared between stdout and stderr: the first non-ASCII chunk
@@ -170,9 +186,9 @@ export function createIbcmdStreamChunkDecoders(mode: IbcmdConsoleOutputEncoding)
   if (mode === 'auto') {
     let decided = false;
     let useUtf8 = true;
+    let legacyEncoding: LegacyCyrillicEncoding = 'cp866';
     const utf8Out = new TextDecoder('utf-8', { fatal: false });
     const utf8Err = new TextDecoder('utf-8', { fatal: false });
-    const fallbackEnc = process.platform === 'win32' ? 'cp1251' : 'cp866';
 
     const decodeAuto = (chunk: Buffer, utf8Dec: InstanceType<typeof TextDecoder>): string => {
       if (!decided) {
@@ -181,14 +197,15 @@ export function createIbcmdStreamChunkDecoders(mode: IbcmdConsoleOutputEncoding)
           decided = true;
           useUtf8 = isLikelyUtf8(chunk);
           if (!useUtf8) {
-            return iconv.decode(chunk, fallbackEnc);
+            legacyEncoding = detectLegacyCyrillicEncoding(chunk);
+            return iconv.decode(chunk, legacyEncoding);
           }
         }
       }
       if (useUtf8) {
         return utf8Dec.decode(chunk, { stream: true });
       }
-      return iconv.decode(chunk, fallbackEnc);
+      return iconv.decode(chunk, legacyEncoding);
     };
 
     return {

--- a/src/services/ibcmd/ibcmdConsoleEncodingTypes.ts
+++ b/src/services/ibcmd/ibcmdConsoleEncodingTypes.ts
@@ -1,6 +1,6 @@
 /**
- * ibcmd may emit OEM (CP866) or UTF-8 depending on build and pipe. Spawn streaming `auto` assumes UTF-8; pick `oem866` / `windows1251`
- * when needed. After {@link decodeIbcmdProcessStreams}, strings are normalized for UI (JavaScript UTF-16).
+ * ibcmd may emit UTF-8, OEM (CP866), or Windows-1251 depending on build and pipe. Spawn streaming `auto` detects these encodings.
+ * After {@link decodeIbcmdProcessStreams}, strings are normalized for UI (JavaScript UTF-16).
  */
 
 /** Values for `1cMetadataTree.ibcmd.consoleOutputEncoding`. */

--- a/test/suite/consoleStreamDecoder.test.ts
+++ b/test/suite/consoleStreamDecoder.test.ts
@@ -2,11 +2,24 @@ import * as assert from 'assert';
 import iconv from 'iconv-lite';
 import {
   createIbcmdStreamChunkDecoders,
+  detectLegacyCyrillicEncoding,
   decodeConsoleStream,
   decodeConsoleStreamAuto,
   decodeIbcmdProcessStreams,
   isLikelyUtf8,
 } from '../../src/services/ibcmd/consoleStreamDecoder';
+
+suite('consoleStreamDecoder detectLegacyCyrillicEncoding', () => {
+  const message = 'Ошибка исключительной блокировки информационной базы.';
+
+  test('detects ibcmd OEM866 output', () => {
+    assert.strictEqual(detectLegacyCyrillicEncoding(iconv.encode(message, 'cp866')), 'cp866');
+  });
+
+  test('detects Windows-1251 output', () => {
+    assert.strictEqual(detectLegacyCyrillicEncoding(iconv.encode(message, 'cp1251')), 'cp1251');
+  });
+});
 
 suite('consoleStreamDecoder isLikelyUtf8', () => {
   test('ASCII-only buffer returns true', () => {
@@ -146,13 +159,16 @@ suite('consoleStreamDecoder createIbcmdStreamChunkDecoders', () => {
     assert.strictEqual(dec.decodeStdout(buf), 'Импорт конфигурации из XML');
   });
 
-  test('auto: CP1251 chunk decoded correctly on Windows', () => {
-    if (process.platform !== 'win32') {
-      return;
-    }
+  test('auto: CP1251 chunk decoded correctly', () => {
     const dec = createIbcmdStreamChunkDecoders('auto');
     const raw = iconv.encode('Справочник', 'cp1251');
     assert.strictEqual(dec.decodeStdout(raw), 'Справочник');
+  });
+
+  test('auto: ibcmd CP866 error is decoded without mojibake', () => {
+    const message = 'Ошибка исключительной блокировки информационной базы.';
+    const dec = createIbcmdStreamChunkDecoders('auto');
+    assert.strictEqual(dec.decodeStderr(iconv.encode(message, 'cp866')), message);
   });
 
   test('auto: ASCII-only chunks defer decision and decode as UTF-8', () => {


### PR DESCRIPTION
## Summary

- keep UTF-8 as the preferred ibcmd output encoding
- distinguish CP866 from Windows-1251 by scoring the decoded Russian text instead of using one fixed fallback
- apply the decision to both buffered and streaming ibcmd output
- cover the exact CP866 lock-error message from #91 and retain CP1251 coverage

## Testing

- consoleStreamDecoder unit suite: 24 passing
- TypeScript compile and MCP session-router bundle verification
- strict source lint and test promise-discipline lint
- official core runner executes the decoder regression successfully; on local macOS the overall run ends with 9 unrelated existing /var versus /private/var path assertions, while current main Linux CI is green

Closes #91