### PR TITLE
feat(cfe): создание CFE и связь с основной конфигурацией

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ docs/features/*
 docs/features/agent-api/*
 !docs/features/agent-api/agent-skill.md
 !docs/features/configuration-compare-merge.md
+!docs/features/cfe-lifecycle/
+!docs/features/cfe-lifecycle/*.md
 !docs/features/diagnostics/
 docs/features/diagnostics/*
 !docs/features/diagnostics/diagnostics-summary-field-dictionary.md

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ VS Code расширение для визуализации и редактир
 
 ### Agent API (для AI-агентов)
 
-CDT 41 предоставляет **69** runtime-команд Agent API для программного управления метаданными, поддержкой конфигурации, EPF/ERF, отладкой, формами, СКД и XDTO-пакетами 1С. Основной способ подключения — встроенный Streamable HTTP MCP endpoint; команды также доступны через `vscode.commands.executeCommand`, а legacy HTTP bridge сохранён только для совместимости. AI-агент (Claude Code, Copilot, MCP-клиент) может:
+CDT 41 предоставляет **73** runtime-команды Agent API для программного управления метаданными, CFE-проектами, поддержкой конфигурации, EPF/ERF, отладкой, формами, СКД и XDTO-пакетами 1С. Основной способ подключения — встроенный Streamable HTTP MCP endpoint; команды также доступны через `vscode.commands.executeCommand`, а legacy HTTP bridge сохранён только для совместимости. AI-агент (Claude Code, Copilot, MCP-клиент) может:
 - **CRUD метаданных** (12 команд) — создавать объекты, добавлять реквизиты/ТЧ/колонки, читать/писать свойства, переименовывать и удалять
 - **Отладка** (15 команд) — запускать отладочную сессию (thinClient / webServer), ставить breakpoints, читать переменные, шагать по коду, фильтровать исключения
 - **Привязки** (2 команды) — resolveBinding (фикстура→база), listBindings (все привязки с базами)
@@ -34,10 +34,11 @@ CDT 41 предоставляет **69** runtime-команд Agent API для �
 - **Формы enterprise** (5 команд, **новое**) — agent.forms.{start, exec, stop, shot, status}: Playwright + ibsrv внутри расширения, без внешних скриптов
 - **СКД** (4 команды, **новое**) — agent.skd.{compile, info, edit, validate}: PowerShell-скрипты внутри расширения, JSON DSL → Template.xml, 26 операций редактирования
 - **XDTO-пакеты** (7 команд, **новое**) — agent.xdto.{listPackages, getPackage, exportXsd, importXsd, createFromXsd, compare, merge}: чтение Package.bin, экспорт/импорт XSD, создание пакетов из XSD, сравнение и объединение XDTO/XSD/XML/BIN
+- **CFE-проекты** (4 команды) — agent.cfe.{listProjects, getContext, validate, createProject}: создание расширения, устойчивое связывание с основной конфигурацией и проверка связей
 
 Мутации Designer XML поддерживаются для форматов `2.17`–`2.21` (платформы 8.3.24–8.5.1): CRUD берёт точную версию из корня `Configuration.xml`, применяет версионные свойства и сохраняет её в новых дочерних XML. Выгрузки `2.13`–`2.16`, XML без версии и неизвестные будущие форматы можно читать, но запись в них блокируется до изменения файлов — без автоматической подмены версии.
 
-MCP-клиент находит endpoint через discovery-файл `.vscode/cdt-agent-bridge.json`: URL находится в `mcp.url`, Bearer token — в верхнеуровневом поле `token`. MCP публикует полный каталог **69/69**: metadata CRUD, support, EPF/ERF, bindings/deploy, types/subsystems, debug, forms, SKD и XDTO. Каждый `cdt_*` tool является строгой тонкой обёрткой над одноимённой Agent-командой; legacy `/command` остаётся доступен без изменений. Объекты адресуются через dot-path: `Catalog.Товары`, `Document.ПриходТовара.Attribute.Склад`.
+MCP-клиент находит endpoint через discovery-файл `.vscode/cdt-agent-bridge.json`: URL находится в `mcp.url`, Bearer token — в верхнеуровневом поле `token`. MCP публикует полный каталог **73/73**: metadata CRUD, CFE, support, EPF/ERF, bindings/deploy, types/subsystems, debug, forms, SKD и XDTO. Каждый `cdt_*` tool является строгой тонкой обёрткой над одноимённой Agent-командой; legacy `/command` остаётся доступен без изменений. Объекты адресуются через dot-path: `Catalog.Товары`, `Document.ПриходТовара.Attribute.Склад`.
 
 Bearer разрешает локальному MCP-клиенту весь Agent API, включая мутации и запуск процессов. `cdt_forms_exec` исполняет произвольный JavaScript, `cdt_debug_evaluate` — BSL-выражение, deploy/debug/forms/SKD/EPF/ERF взаимодействуют с внешними процессами, файлами или информационными базами. Для `cdt_dump_external_processor` и `cdt_build_external_processor` нужно явно выбрать существующую файловую ИБ либо автономный режим с подтверждением риска потери ссылочных типов; оба инструмента создают новые файлы и не перезаписывают существующие. Подключайте только доверенный локальный MCP-клиент; отмена MCP-запроса не прерывает уже запущенную Agent-команду. Полный каталог и inputs: [docs/features/agent-api/agent-skill.md](docs/features/agent-api/agent-skill.md).
 

--- a/docs/features/agent-api/agent-skill.md
+++ b/docs/features/agent-api/agent-skill.md
@@ -1,7 +1,7 @@
 # CDT 41 Agent API — Skill Reference
 
-Расширение CDT 41 для VS Code предоставляет **69** runtime-команд Agent API для программного
-управления метаданными, поддержкой конфигурации, привязками, раскаткой, отладкой, формами enterprise,
+Расширение CDT 41 для VS Code предоставляет **73** runtime-команды Agent API для программного
+управления метаданными, CFE-проектами, поддержкой конфигурации, привязками, раскаткой, отладкой, формами enterprise,
 СКД, XDTO-пакетами и внешними EPF/ERF 1С:Предприятие. Основной транспорт для агента — стандартный Streamable HTTP MCP;
 прямой вызов через `vscode.commands.executeCommand` и legacy `/command` остаются совместимыми.
 
@@ -46,11 +46,12 @@
 
 Подключите MCP-клиент к `mcp.url` и настройте заголовок `Authorization: Bearer <token>` из того же discovery-файла. Endpoint принимает `POST`, `GET` и `DELETE`, использует stateful sessions и отклоняет запросы без token, не с loopback-интерфейса либо с посторонним `Host`/`Origin`.
 
-MCP публикует полный Agent API: **69 tools для 69 runtime-команд**.
+MCP публикует полный Agent API: **73 tools для 73 runtime-команд**.
 
 | Домен | MCP tools |
 |---|---|
 | Configuration/CRUD (13) | `cdt_list_configurations`, `cdt_create_object`, `cdt_get_yaml`, `cdt_list_objects`, `cdt_get_properties`, `cdt_add_attribute`, `cdt_add_tabular_section`, `cdt_add_tabular_section_column`, `cdt_delete_attribute`, `cdt_delete_tabular_section`, `cdt_delete_object`, `cdt_rename_object`, `cdt_set_properties` |
+| CFE project lifecycle (4) | `cdt_cfe_list_projects`, `cdt_cfe_get_context`, `cdt_cfe_validate`, `cdt_cfe_create_project` |
 | Debug (15) | `cdt_debug_start`, `cdt_debug_stop`, `cdt_debug_set_breakpoint`, `cdt_debug_clear_breakpoints`, `cdt_debug_set_exception_filter`, `cdt_debug_wait_for_stop`, `cdt_debug_get_stack_trace`, `cdt_debug_get_scopes`, `cdt_debug_get_variables`, `cdt_debug_evaluate`, `cdt_debug_continue`, `cdt_debug_step_over`, `cdt_debug_step_in`, `cdt_debug_step_out`, `cdt_debug_start_from_binding` |
 | Bindings/deploy (7) | `cdt_resolve_binding`, `cdt_list_bindings`, `cdt_deploy`, `cdt_deploy_selected_objects`, `cdt_deploy_changed_files`, `cdt_pull_selected_objects`, `cdt_export_status` |
 | Support (6) | `cdt_support_get_status`, `cdt_support_set_object_mode`, `cdt_support_enable_object_rules`, `cdt_support_sync`, `cdt_support_verify`, `cdt_support_get_last_run` |
@@ -63,6 +64,15 @@ MCP публикует полный Agent API: **69 tools для 69 runtime-ко
 Имена и inputs соответствуют описанным ниже Agent-командам: например, `cdt_debug_get_variables` вызывает `1c-metadata-tree.agent.debug.getVariables`, а `cdt_xdto_export_xsd` — `1c-metadata-tree.agent.xdto.exportXsd`. Полный нормативный mapping и annotations находятся в [MCP specification](../mcp-agent-adapter/spec.md).
 
 Каждый tool вызывает ровно одну существующую Agent-команду и возвращает исходный `AgentResult` в `structuredContent` и JSON-копию в text content. Input objects строгие: неизвестные поля запрещены. Mutating tools сохраняют очереди Agent API.
+
+### CFE project lifecycle
+
+`cfe.listProjects`, `cfe.getContext` и `cfe.validate` читают устойчивые связи из
+`.vscode/cfe-projects.json`. `cfe.createProject` принимает `baseConfigurationId`, имя расширения,
+назначение, префикс и режим совместимости; необязательный `target` допускается только как путь
+внутри workspace без абсолютных путей и переходов `..`. Ответы содержат JSON-safe DTO: идентификаторы
+конфигураций и метаданные связи, но не сессии VS Code и не абсолютные пути. Создание обновляет
+discovery конфигураций и дерево метаданных.
 
 ### Доверие и опасные операции
 

--- a/docs/features/cfe-lifecycle/design.md
+++ b/docs/features/cfe-lifecycle/design.md
@@ -1,0 +1,205 @@
+# Жизненный цикл расширений конфигурации (CFE)
+
+Статус: принято к реализации для первых трёх частей issue #4.
+
+## Контекст и границы
+
+Цель — сделать расширение конфигурации полноценным проектом CDT, а не ещё одним независимо
+обнаруженным каталогом XML. Первая очередь включает:
+
+1. создание CFE и устойчивую связь с основной CF;
+2. CRUD собственных и заимствованных объектов CFE;
+3. создание перехватов и расширение форм.
+
+Поддерживаются Designer XML форматов 2.17–2.21. EDT, создание пустой CF, создание EPF/ERF и
+преобразование встроенных обработок во внешние не входят в эту очередь. Загрузка/выгрузка CFE
+в информационную базу использует уже существующий `ibcmd --extension`; Configurator остаётся
+резервным transport только там, где `ibcmd` соответствующей версии платформы не предоставляет
+операцию.
+
+## Источник истины и инварианты
+
+- XML основной конфигурации и CFE — источник истины для UUID, состава и принадлежности объектов.
+- Связь проекта хранится явно, но не дублирует доменные данные XML: запись содержит только пути
+  base/CFE и выбранное имя расширения для команд платформы.
+- CFE имеет собственную `ConfigurationSession`; запись никогда не маршрутизируется в сессию CF
+  только потому, что каталог CFE физически вложен в каталог CF.
+- Собственный объект не содержит `ObjectBelonging` и `ExtendedConfigurationObject`.
+- Заимствованный объект содержит `ObjectBelonging=Adopted` и валидный UUID исходного объекта в
+  `ExtendedConfigurationObject`. Имя используется для отображения, UUID — для идентичности.
+- Обычные rename/delete и произвольная запись свойств запрещены для заимствованного объекта.
+  Его разрешённые изменения выражаются отдельными CFE-операциями.
+- Создание собственного объекта применяет `NamePrefix` CFE. Обход префикса возможен только явным
+  параметром в Agent API; UI по умолчанию не предлагает его.
+- Заимствование идемпотентно по UUID исходного объекта. Повторная операция не создаёт дубль.
+- Любая мутация проходит через план, CAS и очередь CFE-сессии. Чтение CF фиксируется fingerprint;
+  изменение исходника до commit даёт конфликт, а не молчаливо устаревшую копию.
+- `ConfigDumpInfo.xml` не синтезируется: минимальный корректный source CFE может его не иметь,
+  платформа создаёт/актуализирует файл при round-trip.
+- Для заимствованной формы ID исходных элементов лежат в диапазоне 1–999999, новые элементы CFE —
+  от 1000000; `BaseForm` обязателен и записывается последним разделом формы.
+- `PropertyState=Extended` создаётся только начиная с формата 2.19.
+- Все UI-команды вызывают тот же application service, что Agent API; MCP остаётся тонкой обёрткой
+  над каждой Agent-командой.
+
+## Рассмотренные варианты
+
+### 1. Запуск готовых Python-скриптов cc-1c-skills
+
+Это самый быстрый путь к широкому покрытию форм, но он добавляет Python как runtime-зависимость,
+усложняет отмену/rollback и увеличивает VSIX. Отклонён как production-архитектура. Скрипты и их
+snapshots используются как спецификация и oracle в тестах.
+
+### 2. Независимая реализация всей модели CFE на TypeScript
+
+Даёт чистую интеграцию с текущими mutation plans, но повторяет большой объём уже проверенных правил
+форматов и повышает риск несовместимого XML. Отклонён как неоправданное дублирование знаний.
+
+### 3. TypeScript application service + портирование канонических правил — выбран
+
+CDT владеет контекстом, безопасностью путей, сессиями, транзакциями, UI и Agent/MCP. Чистые
+TypeScript domain-функции портируют только необходимые правила `cfe-init`, `cfe-borrow`, patch и
+validate из MIT-проекта cc-1c-skills. Совместимость подтверждается его fixtures и реальным
+round-trip платформы.
+
+## Компоненты
+
+```mermaid
+flowchart LR
+    UI["VS Code commands"] --> API["CfeApplicationService"]
+    MCP["MCP cdt_cfe_* tools"] --> AG["Agent CFE commands"]
+    AG --> API
+    API --> CTX["CfeProjectRegistry"]
+    API --> DOM["CFE domain rules"]
+    API --> MUT["Configuration mutation gateway"]
+    API --> PLAT["DeployService / ibcmd"]
+    CTX --> WS[".vscode/cfe-projects.json"]
+    DOM --> CF["base CF XML snapshot"]
+    DOM --> CFE["CFE XML"]
+    MUT --> CFE
+```
+
+`CfeProjectRegistry` разрешает связь base↔CFE и валидирует, что оба пути принадлежат текущему
+workspace. `CfeApplicationService` — единственная прикладная граница. Domain rules не знают о VS
+Code, файловой системе или MCP и возвращают декларативные изменения/диагностику.
+
+## Устойчивая связь CF↔CFE
+
+Файл `.vscode/cfe-projects.json` имеет версионируемую схему:
+
+- `version: 1`;
+- `projects[]` с `baseConfiguration`, `extensionConfiguration`, `extensionName`;
+- пути относительны корня workspace и используют `/`;
+- пара путей уникальна, выход за workspace и symbolic-link escape запрещены.
+
+Случайный runtime `configurationId` в файл не пишется. После discovery registry сопоставляет пути
+с актуальными `ConfigurationSession` и строит `CfeProjectContext`:
+
+- `baseSession`, `extensionSession`;
+- `baseRoot`, `extensionRoot`, `extensionName`;
+- `purpose`, `namePrefix`, `formatVersion`, `compatibilityMode` из CFE XML;
+- UUID и fingerprint основной конфигурации.
+
+Для стандартного каталога `ConfigurationExtensions/<Name>` связь может быть предложена
+автоматически, но становится устойчивой только после записи manifest. Имя расширения для binding
+определяется и из `ConfigurationExtensions`, и из EDT-каталога `Extensions`.
+
+## Создание CFE
+
+Контракт `createProject` принимает base configuration id, имя, purpose, prefix, compatibility mode
+и необязательный относительный target. Сервис:
+
+1. получает точную версию XML основной CF и проверяет её поддержку;
+2. генерирует минимальное CFE с adopted Language и необязательной собственной Role;
+3. пишет весь проект в sibling staging-каталог;
+4. валидирует структуру и XML;
+5. атомарно публикует каталог CFE;
+6. атомарно upsert-ит manifest и инициирует discovery;
+7. при сбое manifest компенсирующе убирает опубликованный каталог; recovery journal сохраняет
+   неопределённый исход.
+
+Основная Configuration.xml при создании CFE не изменяется.
+
+## CRUD и модель принадлежности
+
+Каждая операция сначала получает `CfeObjectIdentity`:
+
+- `ownership: own | adopted`;
+- локальные `type`, `name`, `uuid`, `path`;
+- для adopted — `sourceUuid`, разрешённый через связанную CF.
+
+Generic CRUD получает общий guard. Для own разрешены существующие create/read/update/delete/rename
+с CFE-профилем имени и версии XML. Для adopted generic update/delete/rename отклоняются ошибкой
+`CFE_ADOPTED_OPERATION_REQUIRED`.
+
+`borrowObject` принимает source UUID или dot-path, разрешает его только в связанной CF и создаёт
+канонический adopted shell, GeneratedTypes и требуемые зависимости. Состав `ChildObjects`
+пересчитывается по фактическому XML, потому что имя не определяет принадлежность.
+
+Read-контракты `listObjects`, `getProperties` и связанные UI-модели возвращают ownership и
+`sourceUuid`; это позволяет агенту выбрать допустимую команду до мутации.
+
+## Перехваты
+
+`createInterceptor` принимает adopted target, имя метода, вид `before | after | instead |
+changeAndValidate`, а для последнего — ожидаемую контрольную сумму/версию исходного метода.
+Разрешение цели выполняется по source UUID внутри связанной CF. Domain service парсит модуль BSL,
+создаёт или синхронизирует директиву и тело, не используя regex для поиска строк в комментариях.
+
+Повторный вызов с тем же target/method/kind идемпотентен. Конфликт существующего пользовательского
+тела не перезаписывается и возвращает `CFE_INTERCEPTOR_CONFLICT`. Для
+`changeAndValidate` генерируются канонические маркеры удаления/вставки и сохраняется связь с
+исходной версией для последующей валидации.
+
+## Расширение форм
+
+Операции разделены:
+
+- `createOwnForm` создаёт обычную собственную форму CFE;
+- `borrowForm` создаёт adopted metadata, `Ext/Form.xml` с `BaseForm`, модуль и необходимые
+  зависимости исходного объекта;
+- `extendForm` добавляет элементы/атрибуты/команды CFE и handlers к уже заимствованной форме.
+
+Перед планом `FormIdAllocator` сканирует итоговую форму и выдаёт только ID от 1000000 без
+повторного использования существующих. Serializer сохраняет base-часть, изменения CFE в Part1 и
+канонический порядок `BaseForm`. Обработчики формы используют те же виды `callType`, что модульные
+перехваты. Generic Form editor для adopted формы работает в ограниченном режиме и отправляет
+изменения через `extendForm`, а не перезаписывает исходную модель целиком.
+
+## Agent API и MCP
+
+Добавляются прикладные команды и одноимённые тонкие MCP tools:
+
+- `cfe.listProjects`, `cfe.getContext`, `cfe.validate`;
+- `cfe.createProject`, `cfe.borrowObject`;
+- `cfe.createInterceptor`;
+- `cfe.createOwnForm`, `cfe.borrowForm`, `cfe.extendForm`.
+
+MCP names используют префикс `cdt_cfe_`. Каждая запись имеет strict schema и полный набор
+annotations. `list/get/validate` read-only; остальные destructive/idempotent согласно операции.
+Набор зарегистрированных Agent-команд и MCP catalog остаётся строго равным contract test.
+
+## Ошибки
+
+Публичные стабильные коды: `CFE_PROJECT_NOT_FOUND`, `CFE_RELATION_AMBIGUOUS`,
+`CFE_UNSUPPORTED_FORMAT`, `CFE_SOURCE_CHANGED`, `CFE_SOURCE_OBJECT_NOT_FOUND`,
+`CFE_OWNERSHIP_INVALID`, `CFE_ADOPTED_OPERATION_REQUIRED`, `CFE_DEPENDENCY_UNSUPPORTED`,
+`CFE_INTERCEPTOR_CONFLICT`, `CFE_FORM_ID_EXHAUSTED`, `CFE_VALIDATION_FAILED` и
+`CFE_OUTCOME_UNKNOWN`. Ошибка не содержит абсолютные пути за пределами workspace или connection
+strings.
+
+## Проверка и выпуск
+
+Работа делится на три независимо принимаемые вертикали:
+
+1. context/scaffold/binding/deploy;
+2. ownership-aware CRUD и borrow;
+3. interceptors и forms.
+
+Для каждой обязательны unit/contract tests, integration fixtures 2.17–2.21, rollback/CAS/path
+tests и Agent↔MCP parity. После третьей вертикали выполняется matrix на реальной 8.3.27:
+создание CFE, загрузка, выгрузка, повторный parse и сравнение доменных инвариантов. Сравниваются
+нормализованные контракты и UUID-связи, а не все XML-файлы побайтно, поэтому gate не должен
+существенно увеличивать обычный test-suite; тяжёлый platform round-trip остаётся release/matrix
+проверкой.
+

--- a/docs/features/cfe-lifecycle/implementation-plan.md
+++ b/docs/features/cfe-lifecycle/implementation-plan.md
@@ -1,0 +1,63 @@
+# План реализации CFE lifecycle
+
+План является приложением к `design.md`; контракты и инварианты определяются дизайном.
+
+## Коммит 1 — CFE project context и scaffold
+
+Файлы: `src/services/configurationSession/*`, новый `src/extensionSupport/cfeProject/*`,
+`src/parsers/formatDetector.ts`, `src/bindings/bindingPathUtils.ts`, registration/UI commands,
+Agent CFE operations/commands и MCP catalog, unit/contract fixtures.
+
+Изменения: добавить versioned manifest и registry, точное сопоставление двух sessions, безопасное
+создание/rollback минимального CFE, discovery refresh, распознавание `ConfigurationExtensions`,
+точный выбор CFE binding/deploy, list/get/validate/create команды и MCP parity.
+
+Контракты: `CfeProjectManifestV1`, `CfeProjectContext`, `CfeCreateProjectRequest/Outcome`,
+`CfeApplicationService.listProjects/getContext/validate/createProject`.
+
+## Коммит 2 — ownership-aware CRUD и borrow
+
+Файлы: новый CFE domain/ownership слой, `src/services/elementOperations.ts`, Agent metadata
+operations/DTO, tree/properties providers, CFE Agent/MCP catalog, XML fixtures и tests.
+
+Изменения: классифицировать own/adopted по XML, защитить generic mutation paths, применять prefix
+к own create, разрешать adopted source только по UUID связанной CF, атомарно заимствовать объект с
+GeneratedTypes/зависимостями, публиковать ownership/source UUID в read API.
+
+Контракты: `CfeObjectIdentity`, `CfeOwnershipGuard`, `CfeBorrowObjectRequest/Outcome`,
+`CfeApplicationService.borrowObject` и расширенные read DTO.
+
+## Коммит 3 — перехваты
+
+Файлы: CFE BSL domain/parser, application service, extensionSupport UI adapters, Agent/MCP catalog,
+module fixtures/tests.
+
+Изменения: заменить name/regex-only write semantics структурным разрешением метода и директив,
+добавить before/after/instead/changeAndValidate, идемпотентность, conflict detection и проверку
+версии исходного метода.
+
+Контракты: `CfeInterceptorKind`, `CfeCreateInterceptorRequest/Outcome`,
+`CfeApplicationService.createInterceptor`.
+
+## Коммит 4 — собственные и заимствованные формы
+
+Файлы: CFE form domain/serializer/ID allocator, `src/formEditor/*`, application service,
+Agent/MCP catalog, form fixtures/tests 2.17–2.21.
+
+Изменения: создать own form, канонически borrow base form с зависимостями, ограничить generic edit
+adopted form, добавить extendForm для элементов/атрибутов/команд/handlers, соблюдать BaseForm,
+Part1, ID ranges, callType и versioned PropertyState.
+
+Контракты: `CfeBorrowFormRequest`, `CfeExtendFormRequest`, `CfeFormMutationOutcome`,
+`CfeApplicationService.createOwnForm/borrowForm/extendForm`.
+
+## Коммит 5 — матрица, документация и release gate
+
+Файлы: `test/suite/*`, platform/matrix scripts и fixtures, README/Agent API docs/changelog/package
+metadata только по фактически выпущенным возможностям.
+
+Изменения: negative/security/rollback/CAS tests, Agent↔MCP exact coverage, XML matrix 2.17–2.21,
+реальный round-trip 8.3.27, package audit, compile/test/smoke/build-all, release notes.
+
+Контракты: все публичные команды документированы; release gate не допускает непокрытую Agent
+команду, устаревший MCP count или непроверенный VSIX.

--- a/docs/features/mcp-agent-adapter/spec.md
+++ b/docs/features/mcp-agent-adapter/spec.md
@@ -4,7 +4,7 @@
 
 Дать стандартному MCP-клиенту полный доступ к существующему Agent API расширения без дублирования предметной логики. MCP является новым транспортом над теми же VS Code Agent-командами: каждый tool валидирует input и вызывает ровно одну команду через `vscode.commands.executeCommand`. Legacy Agent Bridge `/command` остаётся совместимым.
 
-Нормативная граница каталога — функция `registerAgentCommands` в `src/agent/agentCommands.ts`. В текущей версии она регистрирует 69 Agent-команд, и MCP публикует их все в отношении 1:1.
+Нормативная граница каталога — функция `registerAgentCommands` в `src/agent/agentCommands.ts`. В текущей версии она регистрирует 73 Agent-команды, и MCP публикует их все в отношении 1:1.
 
 Четыре UI-команды расширения не являются Agent API, не возвращают `AgentResult` и находятся вне scope:
 
@@ -34,6 +34,15 @@
 | `cdt_delete_object` | `1c-metadata-tree.agent.deleteObject` | F/T/F/F |
 | `cdt_rename_object` | `1c-metadata-tree.agent.renameObject` | F/T/F/F |
 | `cdt_set_properties` | `1c-metadata-tree.agent.setProperties` | F/T/F/F |
+
+### CFE projects
+
+| Tool | Agent command | R/D/I/O |
+|---|---|---|
+| `cdt_cfe_list_projects` | `1c-metadata-tree.agent.cfe.listProjects` | T/F/T/F |
+| `cdt_cfe_get_context` | `1c-metadata-tree.agent.cfe.getContext` | T/F/T/F |
+| `cdt_cfe_validate` | `1c-metadata-tree.agent.cfe.validate` | T/F/T/F |
+| `cdt_cfe_create_project` | `1c-metadata-tree.agent.cfe.createProject` | F/T/F/F |
 
 ### Debug
 
@@ -250,7 +259,7 @@ Stop: запрет новых запросов → закрытие MCP sessions
 ## Критерии приёмки
 
 1. Official SDK client проходит `initialize → tools/list → tools/call → DELETE session` по discovery URL и Bearer token.
-2. `tools/list` содержит ровно 69 уникальных tools и ровно 69 уникальных Agent command mappings.
+2. `tools/list` содержит ровно 73 уникальных tools и ровно 73 уникальных Agent command mappings.
 3. Coverage-invariant test реально вызывает `registerAgentCommands` на VS Code stub, получает зарегистрированные IDs из `vscodeTestState.registeredCommandIds` и требует точного равенства с command IDs каталога; regex/source parsing не считается доказательством покрытия.
 4. Четыре перечисленные UI-команды отсутствуют в MCP catalog.
 5. Для каждого tool проверены имя, command id, strict schema, refinements и статические annotations.

--- a/package.json
+++ b/package.json
@@ -493,6 +493,11 @@
         "category": "CDT 41"
       },
       {
+        "command": "1c-metadata-tree.cfe.createProject",
+        "title": "Создать проект расширения конфигурации",
+        "category": "CDT 41"
+      },
+      {
         "command": "1c-metadata-tree.navigateToMainObject",
         "title": "Перейти к объекту конфигурации",
         "category": "CDT 41"
@@ -545,6 +550,26 @@
       {
         "command": "1c-metadata-tree.agent.listConfigurations",
         "title": "Agent: Список открытых конфигураций",
+        "category": "CDT 41 Agent"
+      },
+      {
+        "command": "1c-metadata-tree.agent.cfe.listProjects",
+        "title": "Agent: Список CFE-проектов",
+        "category": "CDT 41 Agent"
+      },
+      {
+        "command": "1c-metadata-tree.agent.cfe.getContext",
+        "title": "Agent: Контекст CFE-проекта",
+        "category": "CDT 41 Agent"
+      },
+      {
+        "command": "1c-metadata-tree.agent.cfe.validate",
+        "title": "Agent: Проверить CFE-проекты",
+        "category": "CDT 41 Agent"
+      },
+      {
+        "command": "1c-metadata-tree.agent.cfe.createProject",
+        "title": "Agent: Создать CFE-проект",
         "category": "CDT 41 Agent"
       },
       {
@@ -1495,6 +1520,11 @@
           "command": "1c-metadata-tree.borrowToExtension",
           "when": "view == 1c-metadata-tree && viewItem =~ /^(Catalog|Document|Enum|Report|DataProcessor|InformationRegister|AccumulationRegister|CommonModule|Role|Subsystem|CommonForm|CommonTemplate|CommonPicture|CommonCommand|ExchangePlan|Constant|ChartOfCharacteristicTypes|ChartOfAccounts|AccountingRegister|ChartOfCalculationTypes|CalculationRegister|BusinessProcess|Task|DocumentJournal|FilterCriterion|SettingsStorage|FunctionalOption|ScheduledJob)$/",
           "group": "3_extension@0"
+        },
+        {
+          "command": "1c-metadata-tree.cfe.createProject",
+          "when": "view == 1c-metadata-tree && viewItem =~ /(^|\\s)cfeBaseConfiguration(\\s|$)/",
+          "group": "3_extension@-1"
         },
         {
           "command": "1c-metadata-tree.navigateToMainObject",

--- a/src/agent/agentBindingResolver.ts
+++ b/src/agent/agentBindingResolver.ts
@@ -20,6 +20,7 @@ export interface ResolvedBinding {
     configPath: string;
     configRelativePath: string;
     workspaceFolder: string;
+    ibcmdExtensionName?: string;
     infobase: {
         id: string;
         name: string;
@@ -34,6 +35,7 @@ export interface ResolvedBinding {
 export interface BindingListItem {
     configRelativePath: string;
     workspaceFolder: string;
+    ibcmdExtensionName?: string;
     infobaseCount: number;
     infobases: Array<{
         id: string;
@@ -111,6 +113,7 @@ export async function resolveBindingCommand(
             configPath: absoluteConfigPath,
             configRelativePath: matched.configRelativePath,
             workspaceFolder: matched.workspaceFolder,
+            ...(matched.ibcmdExtensionName ? { ibcmdExtensionName: matched.ibcmdExtensionName } : {}),
             infobase,
         },
     };
@@ -135,6 +138,7 @@ export async function listBindingsCommand(
         return {
             configRelativePath: b.configRelativePath,
             workspaceFolder: b.workspaceFolder,
+            ...(b.ibcmdExtensionName ? { ibcmdExtensionName: b.ibcmdExtensionName } : {}),
             infobaseCount: infobases.length,
             infobases,
         };
@@ -145,41 +149,77 @@ export async function listBindingsCommand(
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function findBinding(query: string, bindings: ConfigurationBinding[]): ConfigurationBinding | undefined {
+export function findBinding(query: string, bindings: ConfigurationBinding[]): ConfigurationBinding | undefined {
     const isWin = process.platform === 'win32';
     const norm = (p: string): string => {
-        const r = p.replace(/\\/g, '/');
+        const r = p.replace(/\\/g, '/').replace(/\/+$/, '');
         return isWin ? r.toLowerCase() : r;
     };
     const q = norm(query);
+    const extensionRoot = findExtensionRoot(q);
+    const candidates = bindings.flatMap((binding) => {
+        const relativeConfigPath = norm(binding.configRelativePath);
+        const relativeRoot = configRoot(relativeConfigPath);
+        const workspaceFolder = vscode.workspace.workspaceFolders?.find(
+            (folder) => folder.name === binding.workspaceFolder,
+        );
+        const absoluteConfigPath = workspaceFolder
+            ? norm(path.join(workspaceFolder.uri.fsPath, binding.configRelativePath))
+            : undefined;
+        const absoluteRoot = absoluteConfigPath ? configRoot(absoluteConfigPath) : undefined;
+        const match = matchBindingPath(q, relativeConfigPath, relativeRoot, absoluteConfigPath, absoluteRoot);
+        if (match === undefined) { return []; }
 
-    // Strategy 1: exact match by full or relative path
-    for (const b of bindings) {
-        const rel = norm(b.configRelativePath);
-        if (rel === q) {
-            return b;
+        const bindingRoots = [relativeRoot, absoluteRoot].filter(
+            (root): root is string => root !== undefined,
+        );
+        if (extensionRoot && !bindingRoots.some((root) => isSameOrDescendant(root, extensionRoot))) {
+            return [];
         }
-    }
+        return [{ binding, match, specificity: (absoluteRoot ?? relativeRoot).length }];
+    });
 
-    // Strategy 2: query is a substring of configRelativePath (e.g. "FormatSamples/uh")
-    for (const b of bindings) {
-        const rel = norm(b.configRelativePath);
-        if (rel.includes(q + '/') || rel.endsWith(q)) {
-            return b;
-        }
-    }
+    candidates.sort((left, right) => right.match - left.match || right.specificity - left.specificity);
+    return candidates[0]?.binding;
+}
 
-    // Strategy 3: fuzzy match by fixture directory name
-    // "uh" matches "FormatSamples/uh/Configuration.xml"
-    // "empty_conf" matches "FormatSamples/empty_conf/Configuration.xml"
-    for (const b of bindings) {
-        const fixtureName = norm(extractFixtureName(b.configRelativePath));
-        if (fixtureName === q || fixtureName.includes(q)) {
-            return b;
-        }
-    }
+function matchBindingPath(
+    query: string,
+    relativeConfigPath: string,
+    relativeRoot: string,
+    absoluteConfigPath: string | undefined,
+    absoluteRoot: string | undefined,
+): number | undefined {
+    const configPaths = [relativeConfigPath, absoluteConfigPath].filter((value): value is string => value !== undefined);
+    if (configPaths.some((configPath) => query === configPath)) { return 3; }
 
-    return undefined;
+    const roots = [relativeRoot, absoluteRoot].filter((value): value is string => value !== undefined && value.length > 0);
+    if (roots.some((root) => query === root)) { return 2; }
+    if (roots.some((root) => isSameOrDescendant(query, root))) { return 1; }
+
+    const fixtureName = extractFixtureName(relativeConfigPath);
+    return fixtureName === query || fixtureName.includes(query) ? 0 : undefined;
+}
+
+function configRoot(configPath: string): string {
+    const slash = configPath.lastIndexOf('/');
+    return slash < 0 ? '' : configPath.slice(0, slash);
+}
+
+function isSameOrDescendant(candidate: string, root: string): boolean {
+    return candidate === root || candidate.startsWith(`${root}/`);
+}
+
+function findExtensionRoot(configPath: string): string | undefined {
+    const segments = configPath.split('/');
+    const containerIndex = segments.findIndex(
+        (segment) => {
+            const lower = segment.toLowerCase();
+            return lower === 'extensions' || lower === 'configurationextensions';
+        },
+    );
+    if (containerIndex < 0 || !segments[containerIndex + 1]) { return undefined; }
+    return segments.slice(0, containerIndex + 2).join('/');
 }
 
 /** Extract fixture directory name from configRelativePath. */

--- a/src/agent/agentCfeProjectOperations.ts
+++ b/src/agent/agentCfeProjectOperations.ts
@@ -1,0 +1,136 @@
+import * as path from 'path';
+import type { WorkspaceRegistryError } from '../services/configurationSession/WorkspaceRegistry';
+import { CfeProjectError, CfeProjectServiceFactory, type CfeCreateProjectRequest, type CfeProjectContext } from '../extensionSupport/cfeProject';
+import type { AgentResult, ConfigurationScopedParams } from './types';
+
+export const AGENT_CFE_COMMAND_IDS = {
+  listProjects: '1c-metadata-tree.agent.cfe.listProjects',
+  getContext: '1c-metadata-tree.agent.cfe.getContext',
+  validate: '1c-metadata-tree.agent.cfe.validate',
+  createProject: '1c-metadata-tree.agent.cfe.createProject',
+} as const;
+
+export type AgentCfeListProjectsParams = ConfigurationScopedParams;
+export type AgentCfeGetContextParams = Required<Pick<ConfigurationScopedParams, 'configurationId'>>;
+export type AgentCfeValidateParams = ConfigurationScopedParams;
+export interface AgentCfeCreateProjectParams extends CfeCreateProjectRequest {}
+
+/** JSON-safe public representation. ConfigurationSession never crosses the Agent boundary. */
+export interface AgentCfeProjectDto {
+  readonly baseConfigurationId: string;
+  readonly extensionConfigurationId: string;
+  readonly extensionName: string;
+  readonly purpose: string;
+  readonly namePrefix: string;
+  readonly formatVersion: string;
+  readonly compatibilityMode: string;
+  readonly baseConfigurationUuid: string;
+  readonly baseFingerprint: string;
+}
+
+export interface AgentCfeCreateProjectOutcome {
+  readonly status: 'created' | 'outcome-unknown';
+  readonly code?: 'CFE_OUTCOME_UNKNOWN';
+  readonly recoveryJournalPath?: string;
+  readonly context?: AgentCfeProjectDto;
+}
+
+export class AgentCfeProjectOperations {
+  constructor(
+    private readonly getRegistry: () => Promise<import('../services/configurationSession/WorkspaceRegistry').WorkspaceRegistry | null>,
+    private readonly refreshWorkspace: () => Promise<void>,
+  ) {}
+
+  async listProjects(params: AgentCfeListProjectsParams = {}): Promise<AgentResult<{ projects: readonly AgentCfeProjectDto[] }>> {
+    return this.run(params.configurationId, async (service) => ({ projects: (await service.listProjects()).map(toDto) }));
+  }
+
+  async getContext(params: AgentCfeGetContextParams): Promise<AgentResult<AgentCfeProjectDto>> {
+    return this.run(params.configurationId, async (service) => {
+      try {
+        return toDto(await service.getContext(params.configurationId));
+      } catch (error) {
+        if (!(error instanceof CfeProjectError) || error.code !== 'CFE_PROJECT_NOT_FOUND') {
+          throw error;
+        }
+        return toDto(await service.getContextByExtension(params.configurationId));
+      }
+    });
+  }
+
+  async validate(params: AgentCfeValidateParams = {}): Promise<AgentResult<{ valid: true }>> {
+    return this.run(params.configurationId, async (service) => {
+      await service.validate();
+      return { valid: true };
+    });
+  }
+
+  async createProject(params: AgentCfeCreateProjectParams): Promise<AgentResult<AgentCfeCreateProjectOutcome>> {
+    return this.run(params.baseConfigurationId, async (service) => {
+      const outcome = await service.createProject(params);
+      return {
+        status: outcome.status,
+        ...(outcome.code ? { code: outcome.code } : {}),
+        ...(outcome.recoveryJournalPath
+          ? { recoveryJournalPath: toWorkspaceRelativePath(service.workspaceRoot, outcome.recoveryJournalPath) }
+          : {}),
+        ...(outcome.context ? { context: toDto(outcome.context) } : {}),
+      };
+    }, 'write');
+  }
+
+  private async run<T>(
+    configurationId: string | undefined,
+    operation: (service: import('../extensionSupport/cfeProject').CfeProjectService) => Promise<T>,
+    requiredCapability: 'read' | 'write' = 'read',
+  ): Promise<AgentResult<T>> {
+    try {
+      const registry = await this.getRegistry();
+      if (!registry) {
+        throw new Error('Корень конфигурации не найден.');
+      }
+      const session = configurationId
+        ? registry.require(configurationId)
+        : registry.resolveLegacyDefault(requiredCapability);
+      if (!session.identity.capabilities[requiredCapability]) {
+        throw new Error(`Конфигурация ${session.identity.configurationId} не поддерживает ${requiredCapability}.`);
+      }
+      const service = new CfeProjectServiceFactory(registry, { refreshWorkspace: this.refreshWorkspace })
+        .forConfiguration(session.identity.configurationId);
+      return { success: true, data: await operation(service), configurationId: session.identity.configurationId };
+    } catch (error) {
+      return {
+        success: false,
+        code: error instanceof CfeProjectError || isRegistryError(error) ? error.code : 'CFE_OPERATION_FAILED',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}
+
+/** Never expose an absolute workspace path through the Agent/MCP boundary. */
+function toWorkspaceRelativePath(workspaceRoot: string, targetPath: string): string {
+  const relative = path.relative(workspaceRoot, targetPath).replace(/\\/g, '/');
+  return relative && !relative.startsWith('../') && relative !== '..' && !path.isAbsolute(relative)
+    ? relative
+    : '.vscode/cfe-project-recovery.json';
+}
+
+function toDto(context: CfeProjectContext): AgentCfeProjectDto {
+  return {
+    baseConfigurationId: context.baseSession.identity.configurationId,
+    extensionConfigurationId: context.extensionSession.identity.configurationId,
+    extensionName: context.extensionName,
+    purpose: context.purpose,
+    namePrefix: context.namePrefix,
+    formatVersion: context.formatVersion,
+    compatibilityMode: context.compatibilityMode,
+    baseConfigurationUuid: context.baseConfigurationUuid,
+    baseFingerprint: context.baseFingerprint,
+  };
+}
+
+function isRegistryError(error: unknown): error is WorkspaceRegistryError {
+  return Boolean(error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+    && error.constructor?.name === 'WorkspaceRegistryError');
+}

--- a/src/agent/agentCommands.ts
+++ b/src/agent/agentCommands.ts
@@ -103,6 +103,14 @@ import {
     AgentSupportOperations,
     type AgentSupportOperationsDeps,
 } from './agentSupportOperations';
+import {
+    AGENT_CFE_COMMAND_IDS,
+    AgentCfeProjectOperations,
+    type AgentCfeCreateProjectParams,
+    type AgentCfeGetContextParams,
+    type AgentCfeListProjectsParams,
+    type AgentCfeValidateParams,
+} from './agentCfeProjectOperations';
 
 /**
  * Регистрирует Agent API команды.
@@ -123,6 +131,8 @@ export function registerAgentCommands(
     getDebugDeps?: () => AgentDebugOperationsDeps | undefined,
     getDeployDeps?: () => AgentDeployOperationsDeps | undefined,
     getSupportDeps?: () => AgentSupportOperationsDeps | undefined,
+    /** Optional lifecycle hook used by CFE creation after registry discovery succeeds. */
+    refreshCfeLifecycle?: () => Promise<void>,
 ): void {
     const resolveSession = async (
         params: ConfigurationScopedParams = {},
@@ -245,6 +255,32 @@ export function registerAgentCommands(
                 ? { success: true, data: { configurations: registry.list() } }
                 : { success: true, data: { configurations: [] } };
         },
+    );
+
+    // ─── CFE project lifecycle ─────────────────────────────────────────────
+
+    const cfeOperations = new AgentCfeProjectOperations(
+        getConfigurationRegistry,
+        async () => {
+            await getConfigurationRegistry();
+            await refreshCfeLifecycle?.();
+        },
+    );
+    const cfeListProjectsCommand = vscode.commands.registerCommand(
+        AGENT_CFE_COMMAND_IDS.listProjects,
+        async (params: AgentCfeListProjectsParams = {}) => cfeOperations.listProjects(params),
+    );
+    const cfeGetContextCommand = vscode.commands.registerCommand(
+        AGENT_CFE_COMMAND_IDS.getContext,
+        async (params: AgentCfeGetContextParams) => cfeOperations.getContext(params),
+    );
+    const cfeValidateCommand = vscode.commands.registerCommand(
+        AGENT_CFE_COMMAND_IDS.validate,
+        async (params: AgentCfeValidateParams = {}) => cfeOperations.validate(params),
+    );
+    const cfeCreateProjectCommand = vscode.commands.registerCommand(
+        AGENT_CFE_COMMAND_IDS.createProject,
+        async (params: AgentCfeCreateProjectParams) => cfeOperations.createProject(params),
     );
 
     // ─── 1c-metadata-tree.agent.createObject ─────────────────────────────────
@@ -979,6 +1015,7 @@ export function registerAgentCommands(
 
     context.subscriptions.push(
         listConfigurationsCommand,
+        cfeListProjectsCommand, cfeGetContextCommand, cfeValidateCommand, cfeCreateProjectCommand,
         createObjectCommand, getYamlCommand, listObjectsCommand, getPropertiesCommand,
         addAttributeCommand, addTabularSectionCommand, addTabularSectionColumnCommand,
         deleteAttributeCommand, deleteTabularSectionCommand, deleteObjectCommand,

--- a/src/agent/agentDeployOperations.ts
+++ b/src/agent/agentDeployOperations.ts
@@ -19,6 +19,7 @@ import { MetadataType, type TreeNode } from '../models/treeNode';
 import { detectChangedConfigFiles, type IncrementalChangeDetectorDeps } from '../services/ibcmd/incrementalChangeDetector';
 import { runInfobaseConfigExportStatus } from '../infobases/infobaseConfigCommands';
 import type { AgentResult, ConfigurationScopedParams } from './types';
+import { findBinding } from './agentBindingResolver';
 
 export interface AgentDeployOperationsDeps {
     bindingManager: BindingManager;
@@ -118,23 +119,7 @@ export class AgentDeployOperations {
         const allBindings = await this.deps.bindingManager.listAll();
         const localBindings = allBindings.filter((b) => b.workspaceFolder === workspaceFolder!.name);
 
-        const isWin = process.platform === 'win32';
-        const norm = (p: string): string => {
-            const r = path.resolve(p);
-            return isWin ? r.toLowerCase() : r;
-        };
-
-        const configResolved = norm(resolvedConfigPath);
-        let matchedBinding: (typeof localBindings)[number] | undefined;
-        for (const b of localBindings) {
-            const resolved = resolveConfigurationXmlDirectory(workspaceFolder!.uri.fsPath, b.configRelativePath);
-            if (!resolved.ok) { continue; }
-            const src = norm(resolved.sourceDir);
-            if (configResolved === src || configResolved.startsWith(src + path.sep)) {
-                matchedBinding = b;
-                break;
-            }
-        }
+        const matchedBinding = findBinding(resolvedConfigPath, localBindings);
 
         // 4. Validate binding
         if (!matchedBinding) {
@@ -491,6 +476,7 @@ export class AgentDeployOperations {
                         configDumpInfoPath,
                         storage: this.deps.infobaseStorage,
                         token: cts.token,
+                        ibcmdExtensionName: ctx.data!.binding.ibcmdExtensionName,
                     });
 
                 return {

--- a/src/agent/mcpAdapter/catalog/cfeProjectTools.ts
+++ b/src/agent/mcpAdapter/catalog/cfeProjectTools.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import type { McpToolDefinition } from './types';
+import { READ_CLOSED, WRITE_CLOSED } from './types';
+import {
+  cfeCompatibilityMode,
+  cfeConfigurationId,
+  cfeNamePrefix,
+  cfeTargetPath,
+  configurationScopeShape,
+  trimmedElementName,
+} from './schemas';
+
+const cfeListProjectsInput = z.strictObject({ ...configurationScopeShape });
+const cfeGetContextInput = z.strictObject({ configurationId: cfeConfigurationId });
+const cfeValidateInput = z.strictObject({ ...configurationScopeShape });
+const cfeCreateProjectInput = z.strictObject({
+  baseConfigurationId: cfeConfigurationId,
+  extensionName: trimmedElementName,
+  purpose: z.enum(['Customization', 'Patch', 'AddOn']),
+  namePrefix: cfeNamePrefix,
+  compatibilityMode: cfeCompatibilityMode,
+  target: cfeTargetPath.optional(),
+  includeDefaultRole: z.boolean().optional(),
+});
+
+export const CFE_PROJECT_TOOLS: readonly McpToolDefinition[] = [
+  {
+    name: 'cdt_cfe_list_projects',
+    description: 'List persisted CFE projects for the selected configuration workspace.',
+    command: '1c-metadata-tree.agent.cfe.listProjects',
+    inputSchema: cfeListProjectsInput,
+    annotations: READ_CLOSED,
+  },
+  {
+    name: 'cdt_cfe_get_context',
+    description: 'Read the CFE project context for a base or extension configuration.',
+    command: '1c-metadata-tree.agent.cfe.getContext',
+    inputSchema: cfeGetContextInput,
+    annotations: READ_CLOSED,
+  },
+  {
+    name: 'cdt_cfe_validate',
+    description: 'Validate persisted CFE project relations in the selected workspace.',
+    command: '1c-metadata-tree.agent.cfe.validate',
+    inputSchema: cfeValidateInput,
+    annotations: READ_CLOSED,
+  },
+  {
+    name: 'cdt_cfe_create_project',
+    description: 'Create a CFE project and persist its relation to the selected base configuration.',
+    command: '1c-metadata-tree.agent.cfe.createProject',
+    inputSchema: cfeCreateProjectInput,
+    annotations: WRITE_CLOSED,
+  },
+];

--- a/src/agent/mcpAdapter/catalog/schemas.ts
+++ b/src/agent/mcpAdapter/catalog/schemas.ts
@@ -119,6 +119,24 @@ export const metadataType = z.string().refine(
 
 export const configurationScopeShape = { configurationId } as const;
 
+export const cfeConfigurationId = trimmedNonEmptyString;
+export const cfeNamePrefix = z.string().refine(
+  (value) => value.trim().length === 0 || validateElementName(value.trim(), []) === null,
+  { message: 'must be empty or a valid 1C metadata identifier' },
+);
+export const cfeCompatibilityMode = z.string().refine(
+  (value) => value === 'DontUse' || /^Version8_3_\d{1,2}$/.test(value),
+  { message: 'must be DontUse or Version8_3_N' },
+);
+/** Pure pre-dispatch counterpart of the service's workspace-relative path boundary. */
+export const cfeTargetPath = z.string().refine((value) => {
+  const target = value.trim();
+  return Boolean(target)
+    && !target.includes('\0')
+    && !/^(?:[\\/]|[A-Za-z]:)/.test(target)
+    && !target.split(/[\\/]/).some((segment) => segment === '..');
+}, { message: 'must be a workspace-relative path without traversal' });
+
 export const pathInput = z.strictObject({
   ...configurationScopeShape,
   path: agentPath,

--- a/src/agent/mcpAdapter/toolCatalog.ts
+++ b/src/agent/mcpAdapter/toolCatalog.ts
@@ -11,6 +11,7 @@ import { SKD_TOOLS } from './catalog/skdTools';
 import { XDTO_TOOLS } from './catalog/xdtoTools';
 import { SUPPORT_TOOLS } from './catalog/supportTools';
 import { EXTERNAL_PROCESSOR_MCP_TOOLS } from './catalog/externalProcessorTools';
+import { CFE_PROJECT_TOOLS } from './catalog/cfeProjectTools';
 import type { McpToolDefinition } from './catalog/types';
 
 export type { McpToolDefinition } from './catalog/types';
@@ -26,6 +27,7 @@ export const MCP_TOOL_CATALOG: readonly McpToolDefinition[] = [
   ...XDTO_TOOLS,
   ...SUPPORT_TOOLS,
   ...EXTERNAL_PROCESSOR_MCP_TOOLS,
+  ...CFE_PROJECT_TOOLS,
 ];
 
 export type AgentCommandExecutor = (

--- a/src/bindings/bindingPathUtils.ts
+++ b/src/bindings/bindingPathUtils.ts
@@ -17,19 +17,19 @@ export function isSafeConfigRelativePath(relativePath: string): boolean {
 }
 
 /**
- * Имя расширения из пути вида `.../Extensions/<Имя>/.../Configuration.xml` (WOW Phase 4 #64).
+ * Имя расширения из пути EDT `.../Extensions/<Имя>/.../Configuration.xml`
+ * или Designer `.../ConfigurationExtensions/<Имя>/.../Configuration.xml`.
  */
 export function detectIbcmdExtensionNameFromConfigRelativePath(configRelativePath: string): string | undefined {
   const norm = configRelativePath.replace(/\\/g, '/');
-  const lower = norm.toLowerCase();
-  const token = '/extensions/';
-  const idx = lower.indexOf(token);
-  if (idx < 0) {
-    return undefined;
-  }
-  const after = norm.slice(idx + token.length);
-  const seg = after.split('/').find((s) => s.trim().length > 0)?.trim();
-  return seg || undefined;
+  const segments = norm.split('/');
+  const containerIndex = segments.findIndex((segment) => {
+    const lower = segment.trim().toLowerCase();
+    return lower === 'extensions' || lower === 'configurationextensions';
+  });
+  if (containerIndex < 0) { return undefined; }
+  const extensionName = segments.slice(containerIndex + 1).find((segment) => segment.trim().length > 0)?.trim();
+  return extensionName || undefined;
 }
 
 /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,7 @@ import {
   registerUtilityCommandsTrailing,
 } from './utilityCommands';
 import { registerExtensionCommands } from '../extensionSupport/extensionCommands';
+import { registerCfeProjectCommands } from '../extensionSupport/cfeProject/cfeProjectCommands';
 import { registerAgentCommands } from '../agent/agentCommands';
 import { DebugSessionRegistry } from '../agent/debugSessionRegistry';
 import { activateAgentBridge } from '../agent/agentBridgeActivation';
@@ -112,6 +113,12 @@ export async function registerAllCommands({
   context.subscriptions.push(
     configureConfigurationMutationGateway(runConfigurationMutation, runConfigurationPlan),
   );
+  registerCfeProjectCommands({
+    context,
+    state,
+    getConfigurationRegistry,
+    refreshTree: lifecycle.loadMetadataTree,
+  });
   configureSupportServices({
     context,
     state,
@@ -155,6 +162,7 @@ export async function registerAllCommands({
       const facade = state.supportComposition?.facade;
       return facade ? { facade } : undefined;
     },
+    lifecycle.loadMetadataTree,
   );
 
   // Agent Bridge — HTTP сервер для вызова Agent API команд снаружи VS Code

--- a/src/extensionSupport/cfeProject/cfeProjectCommands.ts
+++ b/src/extensionSupport/cfeProject/cfeProjectCommands.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { getSelectedNode } from '../../helpers/commandHelpers';
+import { MetadataType, type TreeNode } from '../../models/treeNode';
+import type { ExtensionState } from '../../state/extensionState';
+import type { WorkspaceRegistry } from '../../services/configurationSession/WorkspaceRegistry';
+import { CfeProjectServiceFactory } from '.';
+
+export interface RegisterCfeProjectCommandsOptions {
+  readonly context: vscode.ExtensionContext;
+  readonly state: ExtensionState;
+  readonly getConfigurationRegistry: () => Promise<WorkspaceRegistry>;
+  readonly refreshTree: () => Promise<void>;
+}
+
+/** VS Code adapter for creating a CFE from the selected base Configuration root. */
+export function registerCfeProjectCommands(options: RegisterCfeProjectCommandsOptions): void {
+  const command = vscode.commands.registerCommand(
+    '1c-metadata-tree.cfe.createProject',
+    async (node?: TreeNode) => {
+      const selected = getSelectedNode(options.state, node);
+      if (!isBaseConfigurationRoot(selected)) {
+        void vscode.window.showWarningMessage('Выберите корневой узел основной конфигурации.');
+        return;
+      }
+      try {
+        const request = await promptCreateProject();
+        if (!request) { return; }
+        const root = options.state.treeDataProvider?.getConfigPathForNode(selected);
+        if (!root) {
+          throw new Error('Не удалось определить каталог выбранной конфигурации.');
+        }
+        const registry = await options.getConfigurationRegistry();
+        const session = await registry.resolveResource(root);
+        const service = new CfeProjectServiceFactory(registry, {
+          refreshWorkspace: async () => { await options.getConfigurationRegistry(); },
+        }).forConfiguration(session.identity.configurationId);
+        const outcome = await service.createProject({ ...request, baseConfigurationId: session.identity.configurationId });
+        await options.refreshTree();
+        if (outcome.status === 'outcome-unknown') {
+          void vscode.window.showWarningMessage('CFE-проект создан, но итог операции требует проверки восстановления.');
+          return;
+        }
+        void vscode.window.showInformationMessage(`Создан CFE-проект «${request.extensionName}».`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        void vscode.window.showErrorMessage(`Не удалось создать CFE-проект: ${message}`);
+      }
+    },
+  );
+  options.context.subscriptions.push(command);
+}
+
+function isBaseConfigurationRoot(node: TreeNode | undefined): node is TreeNode {
+  return Boolean(node && node.type === MetadataType.Configuration && !node.parent && !node.properties.extensionPurpose);
+}
+
+async function promptCreateProject(): Promise<Omit<import('./types').CfeCreateProjectRequest, 'baseConfigurationId'> | undefined> {
+  const extensionName = await vscode.window.showInputBox({
+    prompt: 'Имя расширения конфигурации',
+    placeHolder: 'МоёРасширение',
+    ignoreFocusOut: true,
+  });
+  if (extensionName === undefined) { return undefined; }
+  const purpose = await vscode.window.showQuickPick([
+    { label: 'Доработка', value: 'Customization' as const },
+    { label: 'Исправление', value: 'Patch' as const },
+    { label: 'Дополнение', value: 'AddOn' as const },
+  ], { placeHolder: 'Назначение расширения', ignoreFocusOut: true });
+  if (!purpose) { return undefined; }
+  const namePrefix = await vscode.window.showInputBox({
+    prompt: 'Префикс имён объектов расширения',
+    value: `${extensionName.trim()}_`,
+    ignoreFocusOut: true,
+  });
+  if (namePrefix === undefined) { return undefined; }
+  const compatibilityMode = await vscode.window.showQuickPick([
+    { label: 'Не использовать режим совместимости', value: 'DontUse' },
+    { label: 'Версия 8.3.24', value: 'Version8_3_24' },
+    { label: 'Версия 8.3.27', value: 'Version8_3_27' },
+  ], { placeHolder: 'Режим совместимости расширения', ignoreFocusOut: true });
+  if (!compatibilityMode) { return undefined; }
+  return { extensionName, purpose: purpose.value, namePrefix, compatibilityMode: compatibilityMode.value };
+}

--- a/src/extensionSupport/cfeProject/createProject.ts
+++ b/src/extensionSupport/cfeProject/createProject.ts
@@ -1,0 +1,276 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { assertNoSymlinkSegments, assertPathWithinRoot, validateWorkspaceRelativePath } from '../../services/configurationSession/pathBoundary';
+import { validateElementName } from '../../utils/elementNameValidator';
+import type { WorkspaceRegistry } from '../../services/configurationSession/WorkspaceRegistry';
+import { CfeProjectManifestStorage } from './manifest';
+import { CfeProjectRegistry } from './registry';
+import { CfeProjectError, type CfeCreateProjectOutcome, type CfeCreateProjectRequest, type CfeProjectManifestRecord } from './types';
+
+const SUPPORTED_FORMATS = new Set(['2.17', '2.18', '2.19', '2.20', '2.21']);
+const CONTAINED_OBJECT_CLASS_IDS = [
+  '9cd510cd-abfc-11d4-9434-004095e12fc7',
+  '9fcd25a0-4822-11d4-9414-008048da11f9',
+  'e3687481-0a87-462c-a166-9f34594f9bba',
+  '9de14907-ec23-4a07-96f0-85521cb6b53b',
+  '51f2d5d8-ea4d-4064-8892-82951750031e',
+  'e68182ea-4237-4383-967f-90c1e3370bc7',
+  'fb282519-d103-4dd3-bc12-cb271d631dfc',
+] as const;
+const XML_NAMESPACES = 'xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform"';
+const XML_NAMESPACES_AFTER_PALETTE = 'xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"';
+
+export interface CfeProjectServiceOptions {
+  /** Refreshes WorkspaceRegistry discovery after a successful manifest upsert. */
+  readonly refreshWorkspace?: () => Promise<void>;
+  /** Dependency seams are used by recovery tests and keep recovery behavior deterministic. */
+  readonly manifestStorage?: CfeProjectManifestStorage;
+  readonly removePublishedDirectory?: (workspaceRoot: string, target: string) => Promise<unknown | undefined>;
+}
+
+/** Application boundary for the first CFE vertical: scaffold plus durable relation. */
+export class CfeProjectService {
+  readonly projects: CfeProjectRegistry;
+
+  constructor(
+    readonly workspaceRoot: string,
+    private readonly workspaceRegistry: WorkspaceRegistry,
+    private readonly options: CfeProjectServiceOptions = {},
+  ) {
+    this.projects = new CfeProjectRegistry(workspaceRoot, workspaceRegistry, options.manifestStorage);
+  }
+
+  async listProjects() { return this.projects.list(); }
+  async getContext(baseConfigurationId: string) { return this.projects.getByBase(baseConfigurationId); }
+  async getContextByExtension(extensionConfigurationId: string) { return this.projects.getByExtension(extensionConfigurationId); }
+  async validate(): Promise<void> { await this.projects.list(); }
+
+  async createProject(request: CfeCreateProjectRequest): Promise<CfeCreateProjectOutcome> {
+    const baseSession = this.workspaceRegistry.require(request.baseConfigurationId);
+    const outcome = await baseSession.runExclusive({
+      kind: 'cfe.createProject',
+      execute: async () => this.createInBaseSession(baseSession.identity.rootPath, request),
+    });
+    if (outcome.status === 'committed') {
+      return outcome.value;
+    }
+    if (outcome.status === 'failed' && outcome.error instanceof CfeProjectError) {
+      throw outcome.error;
+    }
+    const error = outcome.status === 'failed' || outcome.status === 'conflict' ? outcome.error : undefined;
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', error?.message ?? 'Не удалось создать CFE-проект.');
+  }
+
+  private async createInBaseSession(baseRoot: string, request: CfeCreateProjectRequest): Promise<CfeCreateProjectOutcome> {
+    const workspaceRoot = await fs.promises.realpath(this.workspaceRoot);
+    const baseRelative = workspaceRelative(workspaceRoot, baseRoot);
+    const baseXml = await fs.promises.readFile(path.join(baseRoot, 'Configuration.xml'), 'utf8');
+    const formatVersion = attribute(baseXml, 'MetaDataObject', 'version');
+    if (!formatVersion || !SUPPORTED_FORMATS.has(formatVersion)) {
+      throw new CfeProjectError('CFE_UNSUPPORTED_FORMAT', 'Поддерживаются только Designer XML форматов 2.17–2.21.');
+    }
+    const extensionName = validateExtensionName(request.extensionName);
+    const purpose = validatePurpose(request.purpose);
+    const namePrefix = normalizeNamePrefix(request.namePrefix, extensionName);
+    const compatibilityMode = validateCompatibilityMode(request.compatibilityMode);
+    const targetRelative = request.target !== undefined
+      ? validateTargetPath(request.target)
+      : `${baseRelative ? `${baseRelative}/` : ''}ConfigurationExtensions/${extensionName}`;
+    const target = await assertPathWithinRoot(workspaceRoot, path.join(workspaceRoot, targetRelative));
+    await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+    if (await exists(target.canonicalTarget)) {
+      throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Каталог CFE-проекта уже существует.');
+    }
+    const language = await readDefaultLanguage(baseRoot, baseXml);
+    const staging = path.join(path.dirname(target.canonicalTarget), `.${path.basename(target.canonicalTarget)}.${randomUUID()}.staging`);
+    let published = false;
+    try {
+      await fs.promises.mkdir(path.dirname(staging), { recursive: true });
+      await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+      await fs.promises.mkdir(staging, { recursive: false });
+      await writeScaffold(staging, {
+        formatVersion, extensionName, purpose, namePrefix, compatibilityMode, language,
+        scriptVariant: readValidatedBaseValue(baseXml, 'ScriptVariant', 'Russian'),
+        interfaceCompatibilityMode: readValidatedBaseValue(baseXml, 'InterfaceCompatibilityMode', 'TaxiEnableVersion8_2'),
+        includeDefaultRole: request.includeDefaultRole === true,
+      });
+      await validateScaffold(staging, formatVersion, language.name);
+      await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+      await fs.promises.rename(staging, target.canonicalTarget);
+      published = true;
+      const record: CfeProjectManifestRecord = {
+        baseConfiguration: baseRelative,
+        extensionConfiguration: targetRelative,
+        extensionName,
+      };
+      try {
+        await this.projects.manifest.upsert(record);
+      } catch (error) {
+        const rollbackError = await (this.options.removePublishedDirectory ?? removePublishedDirectory)(workspaceRoot, target.canonicalTarget);
+        if (rollbackError) {
+          const journalPath = await writeRecoveryJournal(workspaceRoot, record, error, rollbackError);
+          return { status: 'outcome-unknown', code: 'CFE_OUTCOME_UNKNOWN', recoveryJournalPath: journalPath };
+        }
+        throw error;
+      }
+      // Discovery is a cache refresh; persistence and publication are already complete.
+      await this.options.refreshWorkspace?.().catch(() => undefined);
+      const context = await this.projects.findByPaths(baseRoot, target.canonicalTarget).catch(() => undefined);
+      return { status: 'created', context };
+    } finally {
+      if (!published) {
+        await fs.promises.rm(staging, { recursive: true, force: true, maxRetries: 3 }).catch(() => undefined);
+      }
+    }
+  }
+}
+
+interface SourceLanguage { readonly name: string; readonly uuid: string; readonly code: string; }
+interface ScaffoldRequest {
+  readonly formatVersion: string;
+  readonly extensionName: string;
+  readonly purpose: CfeCreateProjectRequest['purpose'];
+  readonly namePrefix: string;
+  readonly compatibilityMode: string;
+  readonly language: SourceLanguage;
+  readonly scriptVariant: string;
+  readonly interfaceCompatibilityMode: string;
+  readonly includeDefaultRole: boolean;
+}
+
+async function readDefaultLanguage(baseRoot: string, baseXml: string): Promise<SourceLanguage> {
+  const defaultLanguage = element(baseXml, 'DefaultLanguage')?.replace(/^Language\./, '');
+  if (!defaultLanguage || validateElementName(defaultLanguage, []) !== null) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'В основной конфигурации не задан язык по умолчанию.');
+  }
+  const xml = await fs.promises.readFile(path.join(baseRoot, 'Languages', `${defaultLanguage}.xml`), 'utf8');
+  const uuid = attribute(xml, 'Language', 'uuid');
+  if (!uuid || !isUuid(uuid)) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Не удалось определить UUID языка основной конфигурации.');
+  }
+  const code = element(xml, 'LanguageCode');
+  if (!code || !/^[a-z]{2,3}(-[A-Z]{2})?$/u.test(code)) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Язык основной конфигурации содержит некорректный LanguageCode.');
+  }
+  return { name: defaultLanguage, uuid, code };
+}
+
+async function writeScaffold(root: string, request: ScaffoldRequest): Promise<void> {
+  const roleName = `${request.namePrefix || `${request.extensionName}_`}ОсновнаяРоль`;
+  const roleSection = request.includeDefaultRole ? `<DefaultRoles><xr:Item xsi:type="xr:MDObjectRef">Role.${xml(roleName)}</xr:Item></DefaultRoles>` : '<DefaultRoles/>';
+  const childRole = request.includeDefaultRole ? `<Role>${xml(roleName)}</Role>` : '';
+  const captions = request.formatVersion === '2.21' ? '<Caption/><ShortCaption/>' : '';
+  const configurationXml = `<?xml version="1.0" encoding="UTF-8"?>\n<MetaDataObject ${xmlNamespaces(request.formatVersion)} version="${request.formatVersion}">\n<Configuration uuid="${randomUUID()}"><InternalInfo>${containedObjects()}</InternalInfo><Properties><ObjectBelonging>Adopted</ObjectBelonging><Name>${xml(request.extensionName)}</Name><Synonym><v8:item><v8:lang>${xml(request.language.code)}</v8:lang><v8:content>${xml(request.extensionName)}</v8:content></v8:item></Synonym><Comment/><ConfigurationExtensionPurpose>${request.purpose}</ConfigurationExtensionPurpose><KeepMappingToExtendedConfigurationObjectsByIDs>true</KeepMappingToExtendedConfigurationObjectsByIDs><NamePrefix>${xml(request.namePrefix)}</NamePrefix><ConfigurationExtensionCompatibilityMode>${xml(request.compatibilityMode)}</ConfigurationExtensionCompatibilityMode><DefaultRunMode>ManagedApplication</DefaultRunMode><UsePurposes><v8:Value xsi:type="app:ApplicationUsePurpose">PlatformApplication</v8:Value></UsePurposes><ScriptVariant>${xml(request.scriptVariant)}</ScriptVariant>${roleSection}<Vendor/><Version/>${captions}<DefaultLanguage>Language.${xml(request.language.name)}</DefaultLanguage><BriefInformation/><DetailedInformation/><Copyright/><VendorInformationAddress/><ConfigurationInformationAddress/><InterfaceCompatibilityMode>${xml(request.interfaceCompatibilityMode)}</InterfaceCompatibilityMode></Properties><ChildObjects><Language>${xml(request.language.name)}</Language>${childRole}</ChildObjects></Configuration>\n</MetaDataObject>\n`;
+  const languageXml = `<?xml version="1.0" encoding="UTF-8"?>\n<MetaDataObject ${xmlNamespaces(request.formatVersion)} version="${request.formatVersion}"><Language uuid="${randomUUID()}"><InternalInfo/><Properties><ObjectBelonging>Adopted</ObjectBelonging><Name>${xml(request.language.name)}</Name><Comment/><ExtendedConfigurationObject>${xml(request.language.uuid)}</ExtendedConfigurationObject><LanguageCode>${xml(request.language.code)}</LanguageCode></Properties></Language></MetaDataObject>\n`;
+  await fs.promises.mkdir(path.join(root, 'Languages'));
+  await writeXmlFile(path.join(root, 'Configuration.xml'), configurationXml);
+  await writeXmlFile(path.join(root, 'Languages', `${request.language.name}.xml`), languageXml);
+  if (request.includeDefaultRole) {
+    await fs.promises.mkdir(path.join(root, 'Roles'));
+    const roleXml = `<?xml version="1.0" encoding="UTF-8"?>\n<MetaDataObject ${xmlNamespaces(request.formatVersion)} version="${request.formatVersion}"><Role uuid="${randomUUID()}"><Properties><Name>${xml(roleName)}</Name><Synonym/><Comment/></Properties></Role></MetaDataObject>\n`;
+    await writeXmlFile(path.join(root, 'Roles', `${roleName}.xml`), roleXml);
+  }
+}
+
+async function validateScaffold(root: string, formatVersion: string, languageName: string): Promise<void> {
+  const [configurationXml, languageXml] = await Promise.all([
+    fs.promises.readFile(path.join(root, 'Configuration.xml'), 'utf8'),
+    fs.promises.readFile(path.join(root, 'Languages', `${languageName}.xml`), 'utf8'),
+  ]);
+  const contained = configurationXml.match(/<xr:ContainedObject>/g) ?? [];
+  const containedClassIds = [...configurationXml.matchAll(/<xr:ClassId>([^<]+)<\/xr:ClassId>/g)].map((match) => match[1]);
+  const containedObjectIds = configurationXml.match(/<xr:ObjectId>[\s\S]*?<\/xr:ObjectId>/g) ?? [];
+  const hasPalette = /xmlns:pal="http:\/\/v8\.1c\.ru\/8\.1\/data\/ui\/colors\/palette"/.test(configurationXml);
+  const hasCaptions = /<Caption\/><ShortCaption\/>/.test(configurationXml);
+  if (attribute(configurationXml, 'MetaDataObject', 'version') !== formatVersion
+    || !attribute(configurationXml, 'Configuration', 'uuid')
+    || element(configurationXml, 'ObjectBelonging') !== 'Adopted'
+    || !element(configurationXml, 'ConfigurationExtensionPurpose')
+    || contained.length !== 7 || containedObjectIds.length !== 7
+    || containedClassIds.length !== CONTAINED_OBJECT_CLASS_IDS.length
+    || containedClassIds.some((classId, index) => classId !== CONTAINED_OBJECT_CLASS_IDS[index])
+    || (formatVersion === '2.21' && (!hasPalette || !hasCaptions))
+    || (formatVersion !== '2.21' && (hasPalette || hasCaptions))
+    || !attribute(languageXml, 'Language', 'uuid')
+    || !element(languageXml, 'ExtendedConfigurationObject')) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Сгенерированный CFE-проект не прошёл структурную проверку.');
+  }
+  if (await exists(path.join(root, 'ConfigDumpInfo.xml'))) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'CFE scaffold не должен создавать ConfigDumpInfo.xml.');
+  }
+}
+
+function workspaceRelative(workspaceRoot: string, root: string): string {
+  const relative = path.relative(workspaceRoot, root).replace(/\\/g, '/');
+  return relative === '' ? '.' : validateWorkspaceRelativePath(relative);
+}
+function validateExtensionName(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Имя расширения должно быть строкой.');
+  }
+  const name = value.trim();
+  if (validateElementName(name, []) !== null) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Имя расширения содержит недопустимые символы.');
+  }
+  return name;
+}
+function validatePurpose(value: unknown): CfeCreateProjectRequest['purpose'] {
+  if (value === 'Customization' || value === 'Patch' || value === 'AddOn') { return value; }
+  throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Указана недопустимая цель расширения.');
+}
+function normalizeNamePrefix(value: unknown, extensionName: string): string {
+  if (typeof value !== 'string') {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Префикс имён расширения должен быть строкой.');
+  }
+  const prefix = value.trim() || `${extensionName}_`;
+  if (validateElementName(prefix, []) !== null) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Префикс имён расширения содержит недопустимые символы.');
+  }
+  return prefix;
+}
+function validateCompatibilityMode(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Режим совместимости расширения должен быть строкой.');
+  }
+  const mode = value.trim();
+  if (mode === 'DontUse' || /^Version8_3_\d{1,2}$/.test(mode)) { return mode; }
+  throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Указан недопустимый режим совместимости расширения.');
+}
+function validateTargetPath(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', 'Каталог CFE-проекта должен быть строкой.');
+  }
+  try {
+    return validateWorkspaceRelativePath(value);
+  } catch (error) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', message(error));
+  }
+}
+function readValidatedBaseValue(xmlText: string, name: 'ScriptVariant' | 'InterfaceCompatibilityMode', fallback: string): string {
+  const value = element(xmlText, name);
+  if (value === undefined) { return fallback; }
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(value)) {
+    throw new CfeProjectError('CFE_VALIDATION_FAILED', `Основная конфигурация содержит недопустимое значение ${name}.`);
+  }
+  return value;
+}
+function xmlNamespaces(formatVersion: string): string {
+  const palette = formatVersion === '2.21' ? ' xmlns:pal="http://v8.1c.ru/8.1/data/ui/colors/palette"' : '';
+  return `${XML_NAMESPACES}${palette} ${XML_NAMESPACES_AFTER_PALETTE}`;
+}
+function containedObjects(): string {
+  return CONTAINED_OBJECT_CLASS_IDS.map((classId) => `<xr:ContainedObject><xr:ClassId>${classId}</xr:ClassId><xr:ObjectId>${randomUUID()}</xr:ObjectId></xr:ContainedObject>`).join('');
+}
+function xml(value: string): string { return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;'); }
+function isUuid(value: string): boolean { return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value); }
+function attribute(xmlText: string, elementName: string, attributeName: string): string | undefined { return new RegExp(`<${elementName}\\b[^>]*\\b${attributeName}\\s*=\\s*["']([^"']+)["']`, 'i').exec(xmlText)?.[1]; }
+function element(xmlText: string, name: string): string | undefined { return new RegExp(`<${name}>([\\s\\S]*?)</${name}>`, 'i').exec(xmlText)?.[1]?.trim(); }
+async function exists(target: string): Promise<boolean> { try { await fs.promises.lstat(target); return true; } catch (error) { if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') { return false; } throw error; } }
+async function writeXmlFile(target: string, content: string): Promise<void> {
+  const normalized = content.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n').replace(/[\r\n]+$/, '');
+  await fs.promises.writeFile(target, `\uFEFF${normalized}`, 'utf8');
+}
+async function removePublishedDirectory(workspaceRoot: string, target: string): Promise<unknown | undefined> { try { const boundary = await assertPathWithinRoot(workspaceRoot, target); await assertNoSymlinkSegments(boundary.canonicalRoot, boundary.canonicalTarget); await fs.promises.rm(boundary.canonicalTarget, { recursive: true, force: true, maxRetries: 3 }); return undefined; } catch (error) { return error; } }
+async function writeRecoveryJournal(workspaceRoot: string, record: CfeProjectManifestRecord, cause: unknown, rollbackError: unknown): Promise<string> { const directory = path.join(workspaceRoot, '.vscode'); await fs.promises.mkdir(directory, { recursive: true }); const journalPath = path.join(directory, `cfe-project-recovery-${randomUUID()}.json`); await fs.promises.writeFile(journalPath, JSON.stringify({ version: 1, record, cause: message(cause), rollbackError: message(rollbackError) }, null, 2), 'utf8'); return journalPath; }
+function message(error: unknown): string { return error instanceof Error ? error.message : String(error); }

--- a/src/extensionSupport/cfeProject/index.ts
+++ b/src/extensionSupport/cfeProject/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './manifest';
+export * from './registry';
+export * from './createProject';
+export * from './serviceFactory';

--- a/src/extensionSupport/cfeProject/manifest.ts
+++ b/src/extensionSupport/cfeProject/manifest.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { assertNoSymlinkSegments, assertPathWithinRoot, validateWorkspaceRelativePath } from '../../services/configurationSession/pathBoundary';
+import { validateElementName } from '../../utils/elementNameValidator';
+import { CFE_PROJECT_MANIFEST_VERSION, type CfeProjectManifestRecord, type CfeProjectManifestV1 } from './types';
+
+const MANIFEST_FILE = 'cfe-projects.json';
+
+/** Versioned, atomic storage for CFE-to-base project relations. */
+export class CfeProjectManifestStorage {
+  private static readonly upsertQueues = new Map<string, Promise<void>>();
+  readonly path: string;
+
+  constructor(readonly workspaceRoot: string) {
+    this.path = path.join(workspaceRoot, '.vscode', MANIFEST_FILE);
+  }
+
+  async read(): Promise<CfeProjectManifestV1> {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await fs.promises.readFile(this.path, 'utf8'));
+    } catch (error) {
+      if (isMissing(error)) {
+        return { version: CFE_PROJECT_MANIFEST_VERSION, projects: [] };
+      }
+      throw new CfeProjectManifestError('Manifest CFE-проектов повреждён.');
+    }
+    return await validateManifest(raw, this.workspaceRoot);
+  }
+
+  async upsert(record: CfeProjectManifestRecord): Promise<CfeProjectManifestV1> {
+    return this.runUpsertExclusive(async () => {
+      const normalized = await normalizeRecord(record, this.workspaceRoot);
+      const manifest = await this.read();
+      const samePair = (candidate: CfeProjectManifestRecord): boolean =>
+        candidate.baseConfiguration === normalized.baseConfiguration
+        && candidate.extensionConfiguration === normalized.extensionConfiguration;
+      const projects = [...manifest.projects.filter((candidate) => !samePair(candidate)), normalized];
+      const next: CfeProjectManifestV1 = { version: CFE_PROJECT_MANIFEST_VERSION, projects };
+      await this.writeAtomic(next);
+      return next;
+    });
+  }
+
+  /** Serializes the whole read-modify-write cycle for every storage instance of one workspace. */
+  private async runUpsertExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const key = await fs.promises.realpath(this.workspaceRoot);
+    const previous = CfeProjectManifestStorage.upsertQueues.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const completion = new Promise<void>((resolve) => { release = resolve; });
+    const queued = previous.catch(() => undefined).then(() => completion);
+    CfeProjectManifestStorage.upsertQueues.set(key, queued);
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (CfeProjectManifestStorage.upsertQueues.get(key) === queued) {
+        CfeProjectManifestStorage.upsertQueues.delete(key);
+      }
+    }
+  }
+
+  async writeAtomic(manifest: CfeProjectManifestV1): Promise<void> {
+    const validated = await validateManifest(manifest, this.workspaceRoot);
+    const root = await fs.promises.realpath(this.workspaceRoot);
+    const target = await assertPathWithinRoot(root, path.join(root, '.vscode', MANIFEST_FILE));
+    const directory = path.dirname(target.canonicalTarget);
+    await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+    await fs.promises.mkdir(directory, { recursive: true });
+    await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+    const temporary = path.join(directory, `.${MANIFEST_FILE}.${randomUUID()}.tmp`);
+    try {
+      await fs.promises.writeFile(temporary, `${JSON.stringify(validated, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+      await fs.promises.rename(temporary, target.canonicalTarget);
+    } finally {
+      await fs.promises.rm(temporary, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+export class CfeProjectManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CfeProjectManifestError';
+  }
+}
+
+export async function validateManifest(value: unknown, workspaceRoot: string): Promise<CfeProjectManifestV1> {
+  if (!value || typeof value !== 'object') {
+    throw new CfeProjectManifestError('Manifest CFE-проектов должен быть объектом.');
+  }
+  const candidate = value as Partial<CfeProjectManifestV1>;
+  if (candidate.version !== CFE_PROJECT_MANIFEST_VERSION || !Array.isArray(candidate.projects)) {
+    throw new CfeProjectManifestError('Поддерживается только manifest CFE-проектов версии 1.');
+  }
+  const projects = await Promise.all(candidate.projects.map((record) => normalizeRecord(record, workspaceRoot)));
+  const pairs = new Set<string>();
+  const extensions = new Set<string>();
+  for (const project of projects) {
+    const pair = `${project.baseConfiguration}\0${project.extensionConfiguration}`;
+    if (pairs.has(pair) || extensions.has(project.extensionConfiguration)) {
+      throw new CfeProjectManifestError('Пары CFE-проектов и пути расширений должны быть уникальны.');
+    }
+    pairs.add(pair);
+    extensions.add(project.extensionConfiguration);
+  }
+  return { version: CFE_PROJECT_MANIFEST_VERSION, projects };
+}
+
+export async function normalizeRecord(value: unknown, workspaceRoot: string): Promise<CfeProjectManifestRecord> {
+  if (!value || typeof value !== 'object') {
+    throw new CfeProjectManifestError('Запись CFE-проекта должна быть объектом.');
+  }
+  const candidate = value as Partial<CfeProjectManifestRecord>;
+  if (typeof candidate.baseConfiguration !== 'string' || typeof candidate.extensionConfiguration !== 'string'
+    || typeof candidate.extensionName !== 'string' || validateElementName(candidate.extensionName.trim(), []) !== null) {
+    throw new CfeProjectManifestError('Запись CFE-проекта содержит некорректные поля.');
+  }
+  const baseConfiguration = normalizeProjectPath(candidate.baseConfiguration);
+  const extensionConfiguration = normalizeProjectPath(candidate.extensionConfiguration);
+  const root = await fs.promises.realpath(workspaceRoot);
+  for (const relativePath of [baseConfiguration, extensionConfiguration]) {
+    const target = await assertPathWithinRoot(root, path.join(root, relativePath));
+    await assertNoSymlinkSegments(target.canonicalRoot, target.canonicalTarget);
+  }
+  return { baseConfiguration, extensionConfiguration, extensionName: candidate.extensionName.trim() };
+}
+
+/** `.` is the only valid spelling for a configuration rooted at the workspace itself. */
+function normalizeProjectPath(value: string): string {
+  return value.trim() === '.' ? '.' : validateWorkspaceRelativePath(value);
+}
+
+function isMissing(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}

--- a/src/extensionSupport/cfeProject/registry.ts
+++ b/src/extensionSupport/cfeProject/registry.ts
@@ -1,0 +1,96 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CfeProjectManifestStorage } from './manifest';
+import { CfeProjectError, type CfeProjectContext, type CfeProjectManifestRecord, type CfeProjectPurpose } from './types';
+import type { WorkspaceRegistry } from '../../services/configurationSession/WorkspaceRegistry';
+
+/** Resolves persisted relations only to currently discovered, exact configuration sessions. */
+export class CfeProjectRegistry {
+  constructor(
+    readonly workspaceRoot: string,
+    private readonly workspaceRegistry: WorkspaceRegistry,
+    readonly manifest = new CfeProjectManifestStorage(workspaceRoot),
+  ) {}
+
+  async list(): Promise<CfeProjectContext[]> {
+    const manifest = await this.manifest.read();
+    return Promise.all(manifest.projects.map((record) => this.resolveRecord(record)));
+  }
+
+  async getByBase(configurationId: string): Promise<CfeProjectContext> {
+    const matches = (await this.list()).filter((context) => context.baseSession.identity.configurationId === configurationId);
+    if (matches.length === 0) {
+      throw new CfeProjectError('CFE_PROJECT_NOT_FOUND', 'Связанный CFE-проект не найден.');
+    }
+    if (matches.length > 1) {
+      throw new CfeProjectError('CFE_RELATION_AMBIGUOUS', 'Для конфигурации найдено несколько CFE-проектов.');
+    }
+    return matches[0]!;
+  }
+
+  /** Resolves a CFE relation from the extension session, which is always unique. */
+  async getByExtension(configurationId: string): Promise<CfeProjectContext> {
+    const matches = (await this.list()).filter((context) => context.extensionSession.identity.configurationId === configurationId);
+    if (matches.length === 0) {
+      throw new CfeProjectError('CFE_PROJECT_NOT_FOUND', 'Связанный CFE-проект не найден.');
+    }
+    if (matches.length > 1) {
+      throw new CfeProjectError('CFE_RELATION_AMBIGUOUS', 'Для расширения найдено несколько CFE-связей.');
+    }
+    return matches[0]!;
+  }
+
+  async findByPaths(baseRoot: string, extensionRoot: string): Promise<CfeProjectContext | undefined> {
+    const root = await fs.promises.realpath(this.workspaceRoot);
+    const baseRelative = toProjectPath(path.relative(root, await fs.promises.realpath(baseRoot)));
+    const extensionRelative = toProjectPath(path.relative(root, await fs.promises.realpath(extensionRoot)));
+    const manifest = await this.manifest.read();
+    const record = manifest.projects.find((item) => item.baseConfiguration === baseRelative && item.extensionConfiguration === extensionRelative);
+    return record ? this.resolveRecord(record) : undefined;
+  }
+
+  private async resolveRecord(record: CfeProjectManifestRecord): Promise<CfeProjectContext> {
+    const workspaceRoot = await fs.promises.realpath(this.workspaceRoot);
+    const baseRoot = await fs.promises.realpath(path.join(workspaceRoot, record.baseConfiguration));
+    const extensionRoot = await fs.promises.realpath(path.join(workspaceRoot, record.extensionConfiguration));
+    const baseSession = this.workspaceRegistry.list().map((item) => this.workspaceRegistry.require(item.configurationId))
+      .find((session) => session.identity.rootPath === baseRoot);
+    const extensionSession = this.workspaceRegistry.list().map((item) => this.workspaceRegistry.require(item.configurationId))
+      .find((session) => session.identity.rootPath === extensionRoot);
+    if (!baseSession || !extensionSession) {
+      throw new CfeProjectError('CFE_PROJECT_NOT_FOUND', 'Конфигурации CFE-проекта ещё не обнаружены в workspace.');
+    }
+    const [baseXml, extensionXml] = await Promise.all([
+      fs.promises.readFile(path.join(baseRoot, 'Configuration.xml'), 'utf8'),
+      fs.promises.readFile(path.join(extensionRoot, 'Configuration.xml'), 'utf8'),
+    ]);
+    const baseConfigurationUuid = attribute(baseXml, 'Configuration', 'uuid');
+    const formatVersion = attribute(extensionXml, 'MetaDataObject', 'version');
+    const purpose = element(extensionXml, 'ConfigurationExtensionPurpose') as CfeProjectPurpose | undefined;
+    const namePrefix = element(extensionXml, 'NamePrefix') ?? '';
+    const compatibilityMode = element(extensionXml, 'ConfigurationExtensionCompatibilityMode') ?? '';
+    if (!baseConfigurationUuid || !formatVersion || !purpose || !isPurpose(purpose)) {
+      throw new CfeProjectError('CFE_VALIDATION_FAILED', 'CFE-проект содержит неполный Configuration.xml.');
+    }
+    return {
+      baseSession, extensionSession, baseRoot, extensionRoot, extensionName: record.extensionName,
+      purpose, namePrefix, formatVersion, compatibilityMode, baseConfigurationUuid,
+      baseFingerprint: crypto.createHash('sha256').update(baseXml).digest('hex'),
+    };
+  }
+}
+
+function attribute(xml: string, elementName: string, attributeName: string): string | undefined {
+  return new RegExp(`<${elementName}\\b[^>]*\\b${attributeName}\\s*=\\s*["']([^"']+)["']`, 'i').exec(xml)?.[1];
+}
+function element(xml: string, name: string): string | undefined {
+  return new RegExp(`<${name}>([\\s\\S]*?)</${name}>`, 'i').exec(xml)?.[1]?.trim();
+}
+function isPurpose(value: string): value is CfeProjectPurpose {
+  return value === 'Customization' || value === 'Patch' || value === 'AddOn';
+}
+function toProjectPath(value: string): string {
+  const normalized = value.replace(/\\/g, '/');
+  return normalized === '' ? '.' : normalized;
+}

--- a/src/extensionSupport/cfeProject/serviceFactory.ts
+++ b/src/extensionSupport/cfeProject/serviceFactory.ts
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import type { WorkspaceRegistry } from '../../services/configurationSession/WorkspaceRegistry';
+import type { ConfigurationId, ConfigurationIdentity } from '../../services/configurationSession/types';
+import { CfeProjectService, type CfeProjectServiceOptions } from './createProject';
+import { CfeProjectError } from './types';
+
+/**
+ * Creates the CFE application service for one exact configuration session.
+ * UI and Agent adapters share this boundary so neither can guess a workspace.
+ */
+export class CfeProjectServiceFactory {
+  constructor(
+    private readonly workspaceRegistry: WorkspaceRegistry,
+    private readonly options: Pick<CfeProjectServiceOptions, 'refreshWorkspace'> = {},
+  ) {}
+
+  forConfiguration(configurationId: ConfigurationId | string): CfeProjectService {
+    const session = this.workspaceRegistry.require(configurationId);
+    return new CfeProjectService(resolveWorkspaceRoot(session.identity), this.workspaceRegistry, this.options);
+  }
+}
+
+function resolveWorkspaceRoot(identity: ConfigurationIdentity): string {
+  const roots = [...new Set(identity.workspaceFolderUris.map(workspaceUriToPath))]
+    .filter((workspaceRoot) => isPathInside(workspaceRoot, identity.rootPath));
+  if (roots.length !== 1) {
+    throw new CfeProjectError(
+      'CFE_RELATION_AMBIGUOUS',
+      roots.length === 0
+        ? 'Конфигурация не принадлежит открытому workspace.'
+        : 'Конфигурация принадлежит нескольким workspace. Уточните workspace.',
+    );
+  }
+  return roots[0]!;
+}
+
+function workspaceUriToPath(uri: string): string {
+  try {
+    return path.resolve(fileURLToPath(uri));
+  } catch {
+    return path.resolve(uri);
+  }
+}
+
+function isPathInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}

--- a/src/extensionSupport/cfeProject/types.ts
+++ b/src/extensionSupport/cfeProject/types.ts
@@ -1,0 +1,64 @@
+import type { ConfigurationSession } from '../../services/configurationSession/ConfigurationSession';
+import type { ConfigurationId } from '../../services/configurationSession/types';
+
+export const CFE_PROJECT_MANIFEST_VERSION = 1 as const;
+
+export interface CfeProjectManifestRecord {
+  readonly baseConfiguration: string;
+  readonly extensionConfiguration: string;
+  readonly extensionName: string;
+}
+
+export interface CfeProjectManifestV1 {
+  readonly version: typeof CFE_PROJECT_MANIFEST_VERSION;
+  readonly projects: readonly CfeProjectManifestRecord[];
+}
+
+export type CfeProjectPurpose = 'Customization' | 'Patch' | 'AddOn';
+
+export interface CfeProjectContext {
+  readonly baseSession: ConfigurationSession;
+  readonly extensionSession: ConfigurationSession;
+  readonly baseRoot: string;
+  readonly extensionRoot: string;
+  readonly extensionName: string;
+  readonly purpose: CfeProjectPurpose;
+  readonly namePrefix: string;
+  readonly formatVersion: string;
+  readonly compatibilityMode: string;
+  readonly baseConfigurationUuid: string;
+  readonly baseFingerprint: string;
+}
+
+export interface CfeCreateProjectRequest {
+  readonly baseConfigurationId: ConfigurationId | string;
+  readonly extensionName: string;
+  readonly purpose: CfeProjectPurpose;
+  readonly namePrefix: string;
+  readonly compatibilityMode: string;
+  /** Workspace-relative directory. Defaults to ConfigurationExtensions/<extensionName> beside the base root. */
+  readonly target?: string;
+  readonly includeDefaultRole?: boolean;
+}
+
+export interface CfeCreateProjectOutcome {
+  readonly status: 'created' | 'outcome-unknown';
+  readonly context?: CfeProjectContext;
+  readonly code?: 'CFE_OUTCOME_UNKNOWN';
+  readonly recoveryJournalPath?: string;
+}
+
+export class CfeProjectError extends Error {
+  constructor(
+    readonly code:
+      | 'CFE_PROJECT_NOT_FOUND'
+      | 'CFE_RELATION_AMBIGUOUS'
+      | 'CFE_UNSUPPORTED_FORMAT'
+      | 'CFE_VALIDATION_FAILED'
+      | 'CFE_OUTCOME_UNKNOWN',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CfeProjectError';
+  }
+}

--- a/src/providers/treeItemBuilder.ts
+++ b/src/providers/treeItemBuilder.ts
@@ -84,7 +84,8 @@ export function buildTreeItem(element: TreeNode, options: TreeItemBuildOptions):
 
     // WOW §2D: context for deploy commands (viewItem when in package.json).
     if (element.type === MetadataType.Configuration) {
-      let cv = 'Configuration';
+      // Keep a stable root kind token so UI commands never appear on a CFE root.
+      let cv = props?.extensionPurpose ? 'Configuration cfeExtensionConfiguration' : 'Configuration cfeBaseConfiguration';
       if (bindingDeco && bindingDeco.boundCount > 0) {
         cv += ' bindingBound';
         // Design §12.5: suffix driven by mass deployment flag, not by count.

--- a/test/suite/agentCommands.debug.test.ts
+++ b/test/suite/agentCommands.debug.test.ts
@@ -82,7 +82,8 @@ suite('registerAgentCommands — debug commands registration', () => {
         const after = ctx.subscriptions.length;
         // 12 CRUD + 2 type + 15 debug + 2 binding + 1 deploy + 4 agent deploy ops + 4 command interface + 4 predefined cot ops
         // + listConfigurations + (5 forms commands + 1 formsOutputChannel) + 4 skd commands + 7 xdto commands + 6 support commands + 2 external processor commands
-        assert.strictEqual(after - before, 70, `Ожидалось 70 подписок, получено ${after - before}`);
+        // + 4 CFE project commands
+        assert.strictEqual(after - before, 74, `Ожидалось 74 подписки, получено ${after - before}`);
     });
 
     test('debug-команды не регистрируются в package.json contributes (только programmatic)', () => {

--- a/test/suite/agentDeployPartialResult.test.ts
+++ b/test/suite/agentDeployPartialResult.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import '../helpers/vscodeStubRegister';
 import {
   DeployService,
@@ -6,8 +9,14 @@ import {
 } from '../../src/bindings/deployService';
 import type { ConfigurationBinding } from '../../src/bindings/models/configurationBinding';
 import type { InfobaseEntry } from '../../src/infobases/models/infobaseEntry';
+import { findBinding } from '../../src/agent/agentBindingResolver';
+import { resetVscodeTestState, vscodeTestState } from '../helpers/vscodeModuleStub';
 
 suite('Agent deploy partial result projection', () => {
+  setup(() => resetVscodeTestState());
+
+  teardown(() => resetVscodeTestState());
+
   test('partial UI summary stays unsuccessful and preserves skipped files in Agent data', async () => {
     const original = DeployService.prototype.deployChangedFiles;
     const summary: DeployRunSummary = {
@@ -72,6 +81,159 @@ suite('Agent deploy partial result projection', () => {
       assert.ok(result.error);
     } finally {
       DeployService.prototype.deployChangedFiles = original;
+    }
+  });
+
+  test('binding resolver selects the deepest CFE binding and exposes its extension name', async () => {
+    const base: ConfigurationBinding = {
+      workspaceFolder: 'ws',
+      configRelativePath: 'Configuration.xml',
+      infobaseIds: ['ib-1'],
+      massDeployment: false,
+    };
+    const extension: ConfigurationBinding = {
+      workspaceFolder: 'ws',
+      configRelativePath: 'ConfigurationExtensions/SalesPatch/Configuration.xml',
+      infobaseIds: ['ib-1'],
+      massDeployment: false,
+      ibcmdExtensionName: 'SalesPatch',
+    };
+    const matched = findBinding(
+      'ConfigurationExtensions/SalesPatch/Catalogs/Goods.xml',
+      [base, extension],
+    );
+    assert.strictEqual(matched, extension);
+
+    const { listBindingsCommand, resolveBindingCommand } = await import('../../src/agent/agentBindingResolver');
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-cfe-binding-'));
+    try {
+      vscodeTestState.mockWorkspaceFolders = [{
+        name: 'ws',
+        index: 0,
+        uri: { fsPath: root, scheme: 'file' },
+      }];
+      assert.strictEqual(
+        findBinding('ConfigurationExtensions/SalesPatch/Catalogs/Goods.xml', [base, extension]),
+        extension,
+        'relative CFE path must resolve with a configured workspace folder',
+      );
+      const result = await resolveBindingCommand(
+        { configPath: path.join(root, 'ConfigurationExtensions', 'SalesPatch', 'Catalogs', 'Goods.xml') },
+        {
+          bindingManager: { listAll: async () => [base, extension] },
+          infobaseStorage: { load: async () => [] },
+          getConfigPath: () => null,
+        } as never,
+      );
+      assert.strictEqual(result.success, true, result.error);
+      assert.strictEqual(result.data?.ibcmdExtensionName, 'SalesPatch');
+      assert.strictEqual(
+        result.data?.configRelativePath,
+        'ConfigurationExtensions/SalesPatch/Configuration.xml',
+      );
+      const listed = await listBindingsCommand({
+        bindingManager: { listAll: async () => [base, extension] },
+        infobaseStorage: { load: async () => [] },
+      } as never);
+      assert.strictEqual(listed.data?.[1]?.ibcmdExtensionName, 'SalesPatch');
+    } finally {
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('deploy resolver does not fall back from an unbound nested CFE to its base CF', async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-cfe-deploy-'));
+    try {
+      const extensionRoot = path.join(root, 'ConfigurationExtensions', 'SalesPatch');
+      await fs.promises.mkdir(extensionRoot, { recursive: true });
+      await fs.promises.writeFile(path.join(root, 'Configuration.xml'), '<Configuration/>', 'utf8');
+      await fs.promises.writeFile(path.join(extensionRoot, 'Configuration.xml'), '<Configuration/>', 'utf8');
+      vscodeTestState.mockWorkspaceFolders = [{
+        name: 'ws',
+        index: 0,
+        uri: { fsPath: root, scheme: 'file' },
+      }];
+      const base: ConfigurationBinding = {
+        workspaceFolder: 'ws',
+        configRelativePath: 'Configuration.xml',
+        infobaseIds: ['ib-1'],
+        massDeployment: false,
+      };
+      assert.strictEqual(
+        findBinding(path.join(extensionRoot, 'Catalogs', 'Goods.xml'), [base]),
+        undefined,
+        'nested CFE path must not resolve to the base binding on case-sensitive platforms',
+      );
+      const catalog: InfobaseEntry[] = [{
+        id: 'ib-1', name: 'Base', type: 'file', filePath: root,
+        hasStoredPassword: false, createdAt: '2026-08-23T00:00:00.000Z',
+      }];
+      const { AgentDeployOperations } = await import('../../src/agent/agentDeployOperations');
+      const operations = new AgentDeployOperations({
+        bindingManager: { listAll: async () => [base] } as never,
+        infobaseStorage: { load: async () => catalog } as never,
+        getConfigPath: () => null,
+      });
+
+      const resolver = Reflect.get(operations, 'resolveDeployContext') as (configPath: string) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      const result = await resolver.call(operations, path.join(extensionRoot, 'Catalogs', 'Goods.xml'));
+      assert.strictEqual(result.success, false);
+      assert.match(result.error ?? '', /привязка базы/i);
+    } finally {
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('exportStatus forwards the binding extension name to ibcmd', async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-cfe-status-'));
+    const configDumpInfoPath = path.join(root, 'ConfigDumpInfo.xml');
+    await fs.promises.writeFile(configDumpInfoPath, '<ConfigDumpInfo/>', 'utf8');
+    const commands = await import('../../src/infobases/infobaseConfigCommands');
+    const original = commands.runInfobaseConfigExportStatus;
+    let passedExtensionName: string | undefined;
+    const stub: typeof original = async (params) => {
+      passedExtensionName = params.ibcmdExtensionName;
+      return { status: 'success', exitCode: 0, userMessage: 'ok', logExcerpt: '' };
+    };
+    (commands as { runInfobaseConfigExportStatus: typeof original }).runInfobaseConfigExportStatus = stub;
+    try {
+      const { AgentDeployOperations } = await import('../../src/agent/agentDeployOperations');
+      const binding: ConfigurationBinding = {
+        workspaceFolder: 'ws',
+        configRelativePath: 'ConfigurationExtensions/SalesPatch/Configuration.xml',
+        infobaseIds: ['ib-1'],
+        massDeployment: false,
+        ibcmdExtensionName: 'SalesPatch',
+      };
+      const entry: InfobaseEntry = {
+        id: 'ib-1', name: 'Base', type: 'file', filePath: root,
+        hasStoredPassword: false, createdAt: '2026-08-23T00:00:00.000Z',
+      };
+      const operations = new AgentDeployOperations({
+        bindingManager: {} as never,
+        infobaseStorage: {} as never,
+        getConfigPath: () => null,
+      });
+      Reflect.set(operations, 'resolveDeployContext', async () => ({
+        success: true,
+        data: {
+          configRoot: root,
+          binding,
+          entries: [entry],
+          catalog: [entry],
+          workspaceFolderRoot: root,
+        },
+      }));
+
+      const result = await operations.exportStatus({});
+      assert.strictEqual(result.success, true, result.error);
+      assert.strictEqual(passedExtensionName, 'SalesPatch');
+    } finally {
+      (commands as { runInfobaseConfigExportStatus: typeof original }).runInfobaseConfigExportStatus = original;
+      await fs.promises.rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/test/suite/bindingPathUtils.test.ts
+++ b/test/suite/bindingPathUtils.test.ts
@@ -50,6 +50,24 @@ suite('bindingPathUtils', () => {
     );
   });
 
+  test('detectIbcmdExtensionNameFromConfigRelativePath reads Designer ConfigurationExtensions layout', () => {
+    assert.strictEqual(
+      detectIbcmdExtensionNameFromConfigRelativePath(
+        'ConfigurationExtensions/Продажи/Configuration.xml',
+      ),
+      'Продажи',
+    );
+  });
+
+  test('detectIbcmdExtensionNameFromConfigRelativePath is case-insensitive for ConfigurationExtensions token', () => {
+    assert.strictEqual(
+      detectIbcmdExtensionNameFromConfigRelativePath(
+        'x/CONFIGURATIONEXTENSIONS/SalesPatch/Catalogs/Goods.xml',
+      ),
+      'SalesPatch',
+    );
+  });
+
   test('detectIbcmdExtensionNameFromConfigRelativePath returns undefined without Extensions segment', () => {
     assert.strictEqual(detectIbcmdExtensionNameFromConfigRelativePath('src/Configuration.xml'), undefined);
   });

--- a/test/suite/cfeProject.test.ts
+++ b/test/suite/cfeProject.test.ts
@@ -1,0 +1,405 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import '../helpers/vscodeStubRegister';
+import { AgentCfeProjectOperations } from '../../src/agent/agentCfeProjectOperations';
+import { registerCfeProjectCommands } from '../../src/extensionSupport/cfeProject/cfeProjectCommands';
+import { CfeProjectManifestError, CfeProjectManifestStorage } from '../../src/extensionSupport/cfeProject/manifest';
+import { CfeProjectService } from '../../src/extensionSupport/cfeProject/createProject';
+import { CfeProjectServiceFactory } from '../../src/extensionSupport/cfeProject/serviceFactory';
+import { MetadataType, type TreeNode } from '../../src/models/treeNode';
+import { WorkspaceRegistry } from '../../src/services/configurationSession/WorkspaceRegistry';
+import { resetVscodeTestState, vscodeTestState } from '../helpers/vscodeModuleStub';
+
+const CONTAINED_OBJECT_CLASS_IDS = [
+  '9cd510cd-abfc-11d4-9434-004095e12fc7', '9fcd25a0-4822-11d4-9414-008048da11f9',
+  'e3687481-0a87-462c-a166-9f34594f9bba', '9de14907-ec23-4a07-96f0-85521cb6b53b',
+  '51f2d5d8-ea4d-4064-8892-82951750031e', 'e68182ea-4237-4383-967f-90c1e3370bc7',
+  'fb282519-d103-4dd3-bc12-cb271d631dfc',
+];
+
+suite('CFE project scaffold', () => {
+  let workspace: string;
+  let base: string;
+  let registry: WorkspaceRegistry;
+
+  setup(async () => {
+    resetVscodeTestState();
+    workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cfe-project-'));
+    base = await createBaseConfiguration(workspace);
+    registry = new WorkspaceRegistry();
+    await registry.refresh([{ configPath: base, workspaceFolderPath: workspace }]);
+  });
+
+  teardown(async () => {
+    await registry.dispose();
+    await fs.promises.rm(workspace, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }).catch(() => undefined);
+    resetVscodeTestState();
+  });
+
+  test('creates a valid 2.17 CFE scaffold, stores its relation atomically and refreshes sessions', async () => {
+    const service = new CfeProjectService(workspace, registry, {
+      refreshWorkspace: async () => registry.refresh([
+        { configPath: base, workspaceFolderPath: workspace },
+        { configPath: path.join(base, 'ConfigurationExtensions', 'TestExtension'), workspaceFolderPath: workspace },
+      ]),
+    });
+    const baseId = registry.list()[0]!.configurationId;
+
+    const result = await service.createProject({
+      baseConfigurationId: baseId,
+      extensionName: 'TestExtension',
+      purpose: 'Customization',
+      namePrefix: 'Ext_',
+      compatibilityMode: 'Version8_3_24',
+      includeDefaultRole: true,
+    });
+
+    assert.strictEqual(result.status, 'created');
+    const extension = path.join(base, 'ConfigurationExtensions', 'TestExtension');
+    const xml = await fs.promises.readFile(path.join(extension, 'Configuration.xml'), 'utf8');
+    assert.match(xml, /<MetaDataObject[^>]*version="2\.17"/);
+    assert.match(xml, /<ConfigurationExtensionPurpose>Customization<\/ConfigurationExtensionPurpose>/);
+    assert.match(xml, /<DefaultLanguage>Language\.Русский<\/DefaultLanguage>/);
+    assert.strictEqual((xml.match(/<xr:ContainedObject>/g) ?? []).length, 7);
+    assert.deepStrictEqual(classIds(xml), CONTAINED_OBJECT_CLASS_IDS);
+    assert.ok(await fileExists(path.join(extension, 'Languages', 'Русский.xml')));
+    assert.ok(await fileExists(path.join(extension, 'Roles', 'Ext_ОсновнаяРоль.xml')));
+    assert.strictEqual(await fileExists(path.join(extension, 'ConfigDumpInfo.xml')), false);
+
+    const manifest = JSON.parse(await fs.promises.readFile(path.join(workspace, '.vscode', 'cfe-projects.json'), 'utf8')) as { version: number; projects: Array<{ baseConfiguration: string; extensionConfiguration: string }> };
+    assert.strictEqual(manifest.version, 1);
+    assert.deepStrictEqual(manifest.projects[0], { baseConfiguration: 'base', extensionConfiguration: 'base/ConfigurationExtensions/TestExtension', extensionName: 'TestExtension' });
+    const context = await service.getContext(baseId);
+    assert.strictEqual(context.extensionRoot, await fs.promises.realpath(extension));
+    assert.strictEqual(context.namePrefix, 'Ext_');
+    assert.strictEqual(context.baseFingerprint.length, 64);
+  });
+
+  test('rejects traversal and duplicate extension records before persisting manifest', async () => {
+    const storage = new CfeProjectManifestStorage(workspace);
+    await assert.rejects(
+      () => storage.upsert({ baseConfiguration: '../base', extensionConfiguration: 'cfe', extensionName: 'Bad' }),
+      /переходом в родительский каталог/i,
+    );
+    await fs.promises.mkdir(path.join(workspace, 'cfe-a'));
+    await fs.promises.mkdir(path.join(workspace, 'cfe-b'));
+    await storage.upsert({ baseConfiguration: 'base', extensionConfiguration: 'cfe-a', extensionName: 'One' });
+    await assert.rejects(
+      () => storage.upsert({ baseConfiguration: 'other-base', extensionConfiguration: 'cfe-a', extensionName: 'Two' }),
+      (error: CfeProjectManifestError) => /уникальны/i.test(error.message),
+    );
+  });
+
+  test('strictly validates scaffold input and defaults an empty name prefix', async () => {
+    const service = new CfeProjectService(workspace, registry);
+    const baseConfigurationId = registry.list()[0]!.configurationId;
+    await assert.rejects(
+      () => service.createProject({ baseConfigurationId, extensionName: '../unsafe', purpose: 'Customization', namePrefix: '', compatibilityMode: 'Version8_3_24' }),
+      (error: { code?: string }) => error.code === 'CFE_VALIDATION_FAILED',
+    );
+    await assert.rejects(
+      () => service.createProject({ baseConfigurationId, extensionName: 'Unsafe', purpose: 'Customization', namePrefix: '' as unknown as string, compatibilityMode: 824 as unknown as string }),
+      (error: { code?: string }) => error.code === 'CFE_VALIDATION_FAILED',
+    );
+    await assert.rejects(
+      () => service.createProject({ baseConfigurationId, extensionName: 'UnsafeTarget', purpose: 'Customization', namePrefix: '', compatibilityMode: 'Version8_3_24', target: 42 as unknown as string }),
+      (error: { code?: string }) => error.code === 'CFE_VALIDATION_FAILED',
+    );
+    await service.createProject({ baseConfigurationId, extensionName: 'DefaultPrefix', purpose: 'Customization', namePrefix: '', compatibilityMode: 'Version8_3_24' });
+    const xml = await fs.promises.readFile(path.join(base, 'ConfigurationExtensions', 'DefaultPrefix', 'Configuration.xml'), 'utf8');
+    assert.match(xml, /<NamePrefix>DefaultPrefix_<\/NamePrefix>/);
+  });
+
+  test('preserves every supported Designer XML format from 2.17 through 2.21', async () => {
+    const created: string[] = [];
+    const service = new CfeProjectService(workspace, registry, {
+      refreshWorkspace: async () => registry.refresh([
+        { configPath: base, workspaceFolderPath: workspace },
+        ...created.map((configPath) => ({ configPath, workspaceFolderPath: workspace })),
+      ]),
+    });
+    const baseId = registry.list()[0]!.configurationId;
+    for (const format of ['2.17', '2.18', '2.19', '2.20', '2.21']) {
+      await fs.promises.writeFile(
+        path.join(base, 'Configuration.xml'),
+        `<?xml version="1.0"?><MetaDataObject version="${format}"><Configuration uuid="11111111-1111-1111-1111-111111111111"><Properties><DefaultLanguage>Language.Русский</DefaultLanguage></Properties></Configuration></MetaDataObject>`,
+        'utf8',
+      );
+      const extension = path.join(base, 'ConfigurationExtensions', `Format${format.replace('.', '')}`);
+      created.push(extension);
+      const result = await service.createProject({
+        baseConfigurationId: baseId,
+        extensionName: path.basename(extension),
+        purpose: 'Patch',
+        namePrefix: 'Patch_',
+        compatibilityMode: 'Version8_3_24',
+      });
+      assert.strictEqual(result.status, 'created');
+      const xml = await fs.promises.readFile(path.join(extension, 'Configuration.xml'), 'utf8');
+      assert.match(xml, new RegExp(`version="${format.replace('.', '\\.')}"`));
+      assert.strictEqual((xml.match(/<xr:ContainedObject>/g) ?? []).length, 7);
+      assert.deepStrictEqual(classIds(xml), CONTAINED_OBJECT_CLASS_IDS);
+      if (format === '2.21') {
+        assert.match(xml, /xmlns:pal="http:\/\/v8\.1c\.ru\/8\.1\/data\/ui\/colors\/palette"/);
+        assert.match(xml, /<Caption\/><ShortCaption\/>/);
+      } else {
+        assert.doesNotMatch(xml, /xmlns:pal=/);
+        assert.doesNotMatch(xml, /<Caption\/>/);
+      }
+    }
+  });
+
+  test('rejects a manifest path that escapes workspace through a symbolic link', async function () {
+    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cfe-outside-'));
+    const link = path.join(workspace, 'outside-link');
+    try {
+      await fs.promises.symlink(outside, link, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch {
+      await fs.promises.rm(outside, { recursive: true, force: true });
+      this.skip();
+      return;
+    }
+    try {
+      const storage = new CfeProjectManifestStorage(workspace);
+      await assert.rejects(
+        () => storage.upsert({ baseConfiguration: 'base', extensionConfiguration: 'outside-link/cfe', extensionName: 'Unsafe' }),
+      );
+    } finally {
+      await fs.promises.rm(outside, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  test('uses dot for a base configuration rooted at workspace', async () => {
+    await createBaseConfigurationAt(workspace, '2.20', 'English', 'en', 'English');
+    await registry.dispose();
+    registry = new WorkspaceRegistry();
+    await registry.refresh([{ configPath: workspace, workspaceFolderPath: workspace }]);
+    const service = new CfeProjectService(workspace, registry, {
+      refreshWorkspace: async () => registry.refresh([
+        { configPath: workspace, workspaceFolderPath: workspace },
+        { configPath: path.join(workspace, 'ConfigurationExtensions', 'RootExtension'), workspaceFolderPath: workspace },
+      ]),
+    });
+
+    const workspaceRealPath = await fs.promises.realpath(workspace);
+    await service.createProject({
+      baseConfigurationId: registry.list().find((item) => item.rootPath === workspaceRealPath)!.configurationId,
+      extensionName: 'RootExtension', purpose: 'AddOn', namePrefix: '', compatibilityMode: 'DontUse',
+    });
+    const manifest = JSON.parse(await fs.promises.readFile(path.join(workspace, '.vscode', 'cfe-projects.json'), 'utf8')) as { projects: Array<{ baseConfiguration: string }> };
+    assert.strictEqual(manifest.projects[0]!.baseConfiguration, '.');
+    const xml = await fs.promises.readFile(path.join(workspace, 'ConfigurationExtensions', 'RootExtension', 'Configuration.xml'), 'utf8');
+    assert.match(xml, /<NamePrefix>RootExtension_<\/NamePrefix>/);
+    assert.match(xml, /<v8:lang>en<\/v8:lang>/);
+    assert.match(xml, /<ScriptVariant>English<\/ScriptVariant>/);
+  });
+
+  test('uses the base language, script variant and interface compatibility mode', async () => {
+    await createBaseConfigurationAt(base, '2.20', 'English', 'en', 'English', 'Version8_3_27', 'TaxiEnableVersion8_3');
+    await registry.refresh([{ configPath: base, workspaceFolderPath: workspace }]);
+    const service = new CfeProjectService(workspace, registry);
+    await service.createProject({
+      baseConfigurationId: registry.list()[0]!.configurationId,
+      extensionName: 'EnglishExtension', purpose: 'Customization', namePrefix: '', compatibilityMode: 'Version8_3_27',
+    });
+    const extension = path.join(base, 'ConfigurationExtensions', 'EnglishExtension');
+    const [configurationXml, languageXml] = await Promise.all([
+      fs.promises.readFile(path.join(extension, 'Configuration.xml'), 'utf8'),
+      fs.promises.readFile(path.join(extension, 'Languages', 'English.xml'), 'utf8'),
+    ]);
+    assert.match(configurationXml, /<v8:lang>en<\/v8:lang>/);
+    assert.match(configurationXml, /<ScriptVariant>English<\/ScriptVariant>/);
+    assert.match(configurationXml, /<InterfaceCompatibilityMode>TaxiEnableVersion8_3<\/InterfaceCompatibilityMode>/);
+    assert.match(languageXml, /<LanguageCode>en<\/LanguageCode>/);
+  });
+
+  test('compensates published directory when manifest upsert fails', async () => {
+    const manifest = new CfeProjectManifestStorage(workspace);
+    const originalUpsert = manifest.upsert.bind(manifest);
+    manifest.upsert = async () => { throw new Error('injected manifest failure'); };
+    const service = new CfeProjectService(workspace, registry, { manifestStorage: manifest });
+    await assert.rejects(
+      () => service.createProject({
+        baseConfigurationId: registry.list()[0]!.configurationId,
+        extensionName: 'ManifestFailure', purpose: 'Customization', namePrefix: 'Failure_', compatibilityMode: 'Version8_3_24',
+      }),
+      /injected manifest failure/,
+    );
+    assert.strictEqual(await fileExists(path.join(base, 'ConfigurationExtensions', 'ManifestFailure')), false);
+    manifest.upsert = originalUpsert;
+  });
+
+  test('writes recovery journal and reports unknown outcome when compensation fails', async () => {
+    const manifest = new CfeProjectManifestStorage(workspace);
+    manifest.upsert = async () => { throw new Error('injected manifest failure'); };
+    const service = new CfeProjectService(workspace, registry, {
+      manifestStorage: manifest,
+      removePublishedDirectory: async () => new Error('injected rollback failure'),
+    });
+    const outcome = await service.createProject({
+      baseConfigurationId: registry.list()[0]!.configurationId,
+      extensionName: 'UnknownOutcome', purpose: 'Customization', namePrefix: 'Unknown_', compatibilityMode: 'Version8_3_24',
+    });
+    assert.deepStrictEqual({ status: outcome.status, code: outcome.code }, { status: 'outcome-unknown', code: 'CFE_OUTCOME_UNKNOWN' });
+    assert.ok(outcome.recoveryJournalPath);
+    assert.ok(await fileExists(outcome.recoveryJournalPath!));
+    assert.ok(await fileExists(path.join(base, 'ConfigurationExtensions', 'UnknownOutcome')));
+  });
+
+  test('serializes concurrent manifest upserts from separate base sessions', async () => {
+    const secondBase = path.join(workspace, 'base-two');
+    await createBaseConfigurationAt(secondBase, '2.20', 'Русский', 'ru', 'Russian');
+    const storageA = new CfeProjectManifestStorage(workspace);
+    const storageB = new CfeProjectManifestStorage(workspace);
+    await Promise.all([
+      storageA.upsert({ baseConfiguration: 'base', extensionConfiguration: 'base/ConfigurationExtensions/One', extensionName: 'One' }),
+      storageB.upsert({ baseConfiguration: 'base-two', extensionConfiguration: 'base-two/ConfigurationExtensions/Two', extensionName: 'Two' }),
+    ]);
+    const manifest = await storageA.read();
+    assert.deepStrictEqual(manifest.projects.map((project) => project.extensionName).sort(), ['One', 'Two']);
+  });
+
+  test('resolves each of two CFE projects by its extension session id', async () => {
+    const extensions: string[] = [];
+    const service = new CfeProjectService(workspace, registry, {
+      refreshWorkspace: async () => registry.refresh([
+        { configPath: base, workspaceFolderPath: workspace },
+        ...extensions.map((configPath) => ({ configPath, workspaceFolderPath: workspace })),
+      ]),
+    });
+    const baseId = registry.list()[0]!.configurationId;
+    for (const extensionName of ['First', 'Second']) {
+      const extension = path.join(base, 'ConfigurationExtensions', extensionName);
+      extensions.push(extension);
+      await service.createProject({ baseConfigurationId: baseId, extensionName, purpose: 'Customization', namePrefix: '', compatibilityMode: 'Version8_3_24' });
+    }
+    const projects = await service.listProjects();
+    assert.strictEqual(projects.length, 2);
+    for (const project of projects) {
+      const resolved = await service.getContextByExtension(project.extensionSession.identity.configurationId);
+      assert.strictEqual(resolved.extensionRoot, project.extensionRoot);
+    }
+    await assert.rejects(() => service.getContext(baseId), (error: { code?: string }) => error.code === 'CFE_RELATION_AMBIGUOUS');
+  });
+
+  test('validates manifest extensionName with the shared 1C identifier contract', async () => {
+    const storage = new CfeProjectManifestStorage(workspace);
+    await assert.rejects(
+      () => storage.upsert({ baseConfiguration: 'base', extensionConfiguration: 'extension', extensionName: 'Процедура' }),
+      (error: CfeProjectManifestError) => /некорректные поля/i.test(error.message),
+    );
+  });
+
+  test('Agent CFE create refreshes registry and lifecycle and returns a JSON-safe DTO', async () => {
+    await registry.refresh([{ configPath: base, workspaceFolderPath: workspace }]);
+    let lifecycleRefreshes = 0;
+    const operations = new AgentCfeProjectOperations(
+      async () => registry,
+      async () => {
+        await registry.refresh([
+          { configPath: base, workspaceFolderPath: workspace },
+          { configPath: path.join(base, 'ConfigurationExtensions', 'AgentExtension'), workspaceFolderPath: workspace },
+        ]);
+        lifecycleRefreshes += 1;
+      },
+    );
+    const baseId = registry.list()[0]!.configurationId;
+    const outcome = await operations.createProject({
+      baseConfigurationId: baseId, extensionName: 'AgentExtension', purpose: 'Customization',
+      namePrefix: 'Agent_', compatibilityMode: 'Version8_3_24',
+    });
+
+    assert.strictEqual(outcome.success, true, outcome.error);
+    assert.strictEqual(lifecycleRefreshes, 1);
+    assert.strictEqual(outcome.data?.status, 'created');
+    assert.ok(outcome.data?.context);
+    assert.ok(outcome.data.context.extensionConfigurationId.length > 0);
+    const serialized = JSON.stringify(outcome);
+    assert.ok(!serialized.includes('baseSession'));
+    assert.ok(!serialized.includes(await fs.promises.realpath(base)));
+  });
+
+  test('service factory rejects a configuration that belongs to multiple workspace roots', async () => {
+    await registry.refresh([
+      { configPath: base, workspaceFolderPath: workspace },
+      { configPath: base, workspaceFolderPath: path.dirname(workspace) },
+    ]);
+    const baseId = registry.list()[0]!.configurationId;
+    assert.throws(
+      () => new CfeProjectServiceFactory(registry).forConfiguration(baseId),
+      (error: { code?: string }) => error.code === 'CFE_RELATION_AMBIGUOUS',
+    );
+  });
+
+  test('UI command creates only from a base root and refreshes the tree', async () => {
+    await registry.refresh([{ configPath: base, workspaceFolderPath: workspace }]);
+    let treeRefreshes = 0;
+    registerCfeProjectCommands({
+      context: { subscriptions: [] } as never,
+      state: {
+        treeDataProvider: { getConfigPathForNode: () => base },
+      } as never,
+      getConfigurationRegistry: async () => registry,
+      refreshTree: async () => { treeRefreshes += 1; },
+    });
+    vscodeTestState.inputBoxQueue.push('UiExtension', 'Ui_');
+    vscodeTestState.quickPickQueue.push(
+      { label: 'Доработка', value: 'Customization' },
+      { label: 'Версия 8.3.24', value: 'Version8_3_24' },
+    );
+    const handler = vscodeTestState.registeredCommandHandlers.get('1c-metadata-tree.cfe.createProject')!;
+    await handler(baseRootNode());
+    assert.strictEqual(treeRefreshes, 1);
+    assert.ok(vscodeTestState.informationLog.some((message) => message.includes('UiExtension')));
+
+    const filesBefore = await fs.promises.readdir(path.join(base, 'ConfigurationExtensions'));
+    await handler(cfeRootNode());
+    assert.ok(vscodeTestState.warningLog.some((message) => message.includes('основной конфигурации')));
+    assert.deepStrictEqual(await fs.promises.readdir(path.join(base, 'ConfigurationExtensions')), filesBefore);
+  });
+});
+
+function baseRootNode(): TreeNode {
+  return { id: 'root', name: 'Configuration', type: MetadataType.Configuration, properties: {}, children: [] };
+}
+
+function cfeRootNode(): TreeNode {
+  return {
+    id: 'root', name: 'Configuration', type: MetadataType.Configuration,
+    properties: { extensionPurpose: 'Customization' }, children: [],
+  };
+}
+
+async function createBaseConfiguration(workspace: string): Promise<string> {
+  const root = path.join(workspace, 'base');
+  await createBaseConfigurationAt(root, '2.17', 'Русский', 'ru', 'Russian');
+  return fs.promises.realpath(root);
+}
+
+async function createBaseConfigurationAt(
+  root: string,
+  format: string,
+  languageName: string,
+  languageCode: string,
+  scriptVariant: string,
+  compatibilityMode = 'Version8_3_24',
+  interfaceCompatibilityMode = 'TaxiEnableVersion8_2',
+): Promise<void> {
+  await fs.promises.mkdir(path.join(root, 'Languages'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(root, 'Configuration.xml'),
+    `<?xml version="1.0"?><MetaDataObject version="${format}"><Configuration uuid="11111111-1111-1111-1111-111111111111"><Properties><DefaultLanguage>Language.${languageName}</DefaultLanguage><ScriptVariant>${scriptVariant}</ScriptVariant><ConfigurationExtensionCompatibilityMode>${compatibilityMode}</ConfigurationExtensionCompatibilityMode><InterfaceCompatibilityMode>${interfaceCompatibilityMode}</InterfaceCompatibilityMode></Properties><ChildObjects><Language>${languageName}</Language></ChildObjects></Configuration></MetaDataObject>`,
+    'utf8',
+  );
+  await fs.promises.writeFile(path.join(root, 'Languages', `${languageName}.xml`), `<MetaDataObject version="${format}"><Language uuid="22222222-2222-2222-2222-222222222222"><Properties><LanguageCode>${languageCode}</LanguageCode></Properties></Language></MetaDataObject>`, 'utf8');
+}
+
+async function fileExists(target: string): Promise<boolean> {
+  try { await fs.promises.access(target); return true; } catch { return false; }
+}
+
+function classIds(xml: string): string[] {
+  return [...xml.matchAll(/<xr:ClassId>([^<]+)<\/xr:ClassId>/g)].map((match) => match[1]!);
+}

--- a/test/suite/coreSuites.ts
+++ b/test/suite/coreSuites.ts
@@ -150,6 +150,7 @@ export const coreSuiteFiles: string[] = [
   'suite/typeFormatterAndFilterState.test.js',
   'suite/configurationXmlUpdater.test.js',
   'suite/configurationSession.test.js',
+  'suite/cfeProject.test.js',
   'suite/atomicFileStorage.test.js',
   'suite/mutationPlan.test.js',
   'suite/bslModuleParser.test.js',

--- a/test/suite/extensionManifestContracts.test.ts
+++ b/test/suite/extensionManifestContracts.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { registerUtilityCommandsLeading } from '../../src/commands/utilityCommands';
+import type { ExtensionState } from '../../src/state/extensionState';
 import { resetVscodeTestState, vscodeTestState } from '../helpers/vscodeModuleStub';
 
 const TEST_COMMAND_IDS = [
@@ -12,6 +13,21 @@ const TEST_COMMAND_IDS = [
   '1c-metadata-tree.diagnoseRevealForTest',
   '1c-metadata-tree.getPropertiesOpenStateForTest',
 ] as const;
+
+interface PackageManifest {
+  readonly main: string;
+  readonly activationEvents: readonly string[];
+  readonly capabilities?: { readonly virtualWorkspaces?: { readonly supported?: boolean } };
+  readonly contributes: {
+    readonly views: { readonly explorer: unknown };
+    readonly commands: ReadonlyArray<{ readonly command: string }>;
+    readonly menus: {
+      readonly commandPalette: ReadonlyArray<{ readonly command: string; readonly when?: string }>;
+      readonly 'view/item/context': unknown;
+      readonly 'explorer/context': unknown;
+    };
+  };
+}
 
 suite('extension manifest contracts', () => {
   test('activates for 1C workspace markers and the explicit BSL debug resolver', () => {
@@ -74,9 +90,24 @@ suite('extension manifest contracts', () => {
         .filter((command: string) => command.startsWith('1c-metadata-tree.agent.')),
     );
 
-    assert.strictEqual(registered.size, 69, 'Update the documented Agent API count intentionally.');
-    assert.strictEqual(contributed.size, 69, 'Manifest must contribute exactly the documented Agent API.');
+    assert.strictEqual(registered.size, 73, 'Update the documented Agent API count intentionally.');
+    assert.strictEqual(contributed.size, 73, 'Manifest must contribute exactly the documented Agent API.');
     assert.deepStrictEqual([...contributed].sort(), [...registered].sort());
+  });
+
+  test('shows CFE project creation only for a base configuration root', () => {
+    const explorer = readPackageJson().contributes.menus['view/item/context'] as Array<{
+      command: string;
+      when?: string;
+    }>;
+    assert.deepStrictEqual(
+      explorer.find((entry) => entry.command === '1c-metadata-tree.cfe.createProject'),
+      {
+        command: '1c-metadata-tree.cfe.createProject',
+        when: 'view == 1c-metadata-tree && viewItem =~ /(^|\\s)cfeBaseConfiguration(\\s|$)/',
+        group: '3_extension@-1',
+      },
+    );
   });
 
   test('declares EPF/ERF UI and hidden Agent commands with exact Explorer routing', () => {
@@ -163,14 +194,14 @@ suite('extension manifest contracts', () => {
 
 function registerLeadingCommands(extensionMode: vscode.ExtensionMode): void {
   registerUtilityCommandsLeading({
-    state: {} as any,
+    state: {} as ExtensionState,
     loadMetadataTree: async () => undefined,
     extensionContext: { extensionMode } as vscode.ExtensionContext,
   });
 }
 
-function readPackageJson(): any {
-  return JSON.parse(fs.readFileSync(path.join(repositoryRoot(), 'package.json'), 'utf-8'));
+function readPackageJson(): PackageManifest {
+  return JSON.parse(fs.readFileSync(path.join(repositoryRoot(), 'package.json'), 'utf-8')) as PackageManifest;
 }
 
 function repositoryRoot(): string {
@@ -180,6 +211,7 @@ function repositoryRoot(): string {
 function registeredAgentCommandIds(root: string): Set<string> {
   const registrySources = [
     path.join(root, 'src', 'agent', 'agentCommands.ts'),
+    path.join(root, 'src', 'agent', 'agentCfeProjectOperations.ts'),
     path.join(root, 'src', 'agent', 'agentSupportOperations.ts'),
   ];
   return new Set(registrySources.flatMap((sourcePath) => {

--- a/test/suite/mcpAdapter.test.ts
+++ b/test/suite/mcpAdapter.test.ts
@@ -51,7 +51,7 @@ function signal(aborted = false): AbortSignal {
 suite('MCP adapter: tool contract', () => {
   test('registerMcpTools preserves every catalog schema and annotation object', () => {
     const tools = captureRegisteredTools(async () => ({ success: true }));
-    assert.strictEqual(tools.length, 69);
+    assert.strictEqual(tools.length, 73);
     assert.deepStrictEqual(
       tools.map(({ name, config }) => ({ name, annotations: config.annotations })),
       MCP_TOOL_CATALOG.map(({ name, annotations }) => ({ name, annotations })),
@@ -86,6 +86,7 @@ suite('MCP adapter: AgentResult mapping and dispatch', () => {
     });
     const cases: ReadonlyArray<readonly [string, Record<string, unknown>, string]> = [
       ['cdt_list_objects', { type: 'Catalog', query: 'good' }, '1c-metadata-tree.agent.listObjects'],
+      ['cdt_cfe_list_projects', { configurationId: 'cfg' }, '1c-metadata-tree.agent.cfe.listProjects'],
       ['cdt_create_object', { type: 'Catalog', name: 'Goods' }, '1c-metadata-tree.agent.createObject'],
       ['cdt_debug_stop', { sessionId: 's1' }, '1c-metadata-tree.agent.debug.stop'],
       ['cdt_forms_status', {}, '1c-metadata-tree.agent.forms.status'],

--- a/test/suite/mcpAgentCoverage.test.ts
+++ b/test/suite/mcpAgentCoverage.test.ts
@@ -98,6 +98,11 @@ const EXPECTED_TOOLS: readonly ExpectedTool[] = [
 
   tool('cdt_dump_external_processor', 'dumpExternalProcessor', 'writeOpen'),
   tool('cdt_build_external_processor', 'buildExternalProcessor', 'writeOpen'),
+
+  tool('cdt_cfe_list_projects', 'cfe.listProjects', 'readClosed'),
+  tool('cdt_cfe_get_context', 'cfe.getContext', 'readClosed'),
+  tool('cdt_cfe_validate', 'cfe.validate', 'readClosed'),
+  tool('cdt_cfe_create_project', 'cfe.createProject', 'writeClosed'),
 ];
 
 const EXPECTED_ANNOTATIONS: Readonly<Record<AnnotationKind, Readonly<Record<string, boolean>>>> = {
@@ -110,6 +115,13 @@ const EXPECTED_ANNOTATIONS: Readonly<Record<AnnotationKind, Readonly<Record<stri
 
 const VALID_INPUTS: Readonly<Record<string, Record<string, unknown>>> = {
   cdt_list_configurations: {},
+  cdt_cfe_list_projects: { configurationId: 'cfg' },
+  cdt_cfe_get_context: { configurationId: 'cfg' },
+  cdt_cfe_validate: { configurationId: 'cfg' },
+  cdt_cfe_create_project: {
+    baseConfigurationId: 'cfg', extensionName: 'Extension', purpose: 'Customization',
+    namePrefix: 'Ext_', compatibilityMode: 'Version8_3_24', target: 'extensions/Extension', includeDefaultRole: true,
+  },
   cdt_create_object: { configurationId: 'cfg', type: 'Catalog', name: 'Goods', synonym: 'Goods', properties: { nested: { enabled: true }, values: [1, null] } },
   cdt_get_yaml: { configurationId: 'cfg', path: 'Catalog.Goods' },
   cdt_list_objects: { configurationId: 'cfg', type: 'Catalog', query: 'good' },
@@ -219,6 +231,11 @@ interface InvalidRefinementCase {
 }
 
 const INVALID_REFINEMENT_CASES: readonly InvalidRefinementCase[] = [
+  { label: 'CFE create rejects an invalid extension identifier', tool: 'cdt_cfe_create_project', input: { baseConfigurationId: 'cfg', extensionName: 'Bad-Name', purpose: 'Customization', namePrefix: 'Ext_', compatibilityMode: 'Version8_3_24' } },
+  { label: 'CFE create rejects an invalid name prefix', tool: 'cdt_cfe_create_project', input: { baseConfigurationId: 'cfg', extensionName: 'Extension', purpose: 'Customization', namePrefix: 'Bad-Name', compatibilityMode: 'Version8_3_24' } },
+  { label: 'CFE create rejects an invalid compatibility mode', tool: 'cdt_cfe_create_project', input: { baseConfigurationId: 'cfg', extensionName: 'Extension', purpose: 'Customization', namePrefix: 'Ext_', compatibilityMode: 'Version8_2_24' } },
+  { label: 'CFE create rejects an absolute target before dispatch', tool: 'cdt_cfe_create_project', input: { baseConfigurationId: 'cfg', extensionName: 'Extension', purpose: 'Customization', namePrefix: 'Ext_', compatibilityMode: 'Version8_3_24', target: 'C:/outside' } },
+  { label: 'CFE create rejects a traversal target before dispatch', tool: 'cdt_cfe_create_project', input: { baseConfigurationId: 'cfg', extensionName: 'Extension', purpose: 'Customization', namePrefix: 'Ext_', compatibilityMode: 'Version8_3_24', target: 'extensions/../outside' } },
   { label: 'createObject empty type', tool: 'cdt_create_object', input: { type: '', name: 'Goods' } },
   { label: 'createObject empty name', tool: 'cdt_create_object', input: { type: 'Catalog', name: '' } },
   { label: 'createObject invalid type identifier', tool: 'cdt_create_object', input: { type: 'Bad-Type', name: 'Goods' } },
@@ -359,10 +376,10 @@ suite('MCP Agent catalog coverage', () => {
   setup(resetVscodeTestState);
   teardown(resetVscodeTestState);
 
-  test('catalog has the exact 69 name-command-annotation contracts', () => {
-    assert.strictEqual(EXPECTED_TOOLS.length, 69, 'test oracle must enumerate all 69 tools');
-    assert.strictEqual(new Set(EXPECTED_TOOLS.map(({ name }) => name)).size, 69);
-    assert.strictEqual(new Set(EXPECTED_TOOLS.map(({ command }) => command)).size, 69);
+  test('catalog has the exact 73 name-command-annotation contracts', () => {
+    assert.strictEqual(EXPECTED_TOOLS.length, 73, 'test oracle must enumerate all 73 tools');
+    assert.strictEqual(new Set(EXPECTED_TOOLS.map(({ name }) => name)).size, 73);
+    assert.strictEqual(new Set(EXPECTED_TOOLS.map(({ command }) => command)).size, 73);
 
     assert.deepStrictEqual(
       MCP_TOOL_CATALOG.map(({ name, command, annotations }) => ({ name, command, annotations })),
@@ -405,8 +422,8 @@ suite('MCP Agent catalog coverage', () => {
     const registered = vscodeTestState.registeredCommandIds;
     const expectedCommands = EXPECTED_TOOLS.map(({ command }) => command);
 
-    assert.strictEqual(registered.length, 69);
-    assert.strictEqual(new Set(registered).size, 69);
+    assert.strictEqual(registered.length, 73);
+    assert.strictEqual(new Set(registered).size, 73);
     assert.deepStrictEqual([...registered].sort(), [...expectedCommands].sort());
     for (const uiCommand of [
       '1c-metadata-tree.borrowToExtension',
@@ -419,7 +436,7 @@ suite('MCP Agent catalog coverage', () => {
     }
   });
 
-  test('all 69 valid fixtures pass and every root schema rejects an extra property', () => {
+  test('all 73 valid fixtures pass and every root schema rejects an extra property', () => {
     assert.deepStrictEqual(Object.keys(VALID_INPUTS).sort(), EXPECTED_TOOLS.map(({ name }) => name).sort());
     for (const { name } of EXPECTED_TOOLS) {
       const input = VALID_INPUTS[name];

--- a/test/suite/mcpBridgeTransport.test.ts
+++ b/test/suite/mcpBridgeTransport.test.ts
@@ -210,7 +210,7 @@ suite('MCP bridge: official SDK client and lifecycle', () => {
     await client.connect(transport);
     assert.ok(transport.sessionId, 'initialize must establish a stateful MCP session');
     const listed = await client.listTools();
-    assert.strictEqual(listed.tools.length, 69);
+    assert.strictEqual(listed.tools.length, 73);
     assert.deepStrictEqual(
       listed.tools.map((tool) => tool.name),
       MCP_TOOL_CATALOG.map((tool) => tool.name),

--- a/test/suite/smoke/mcpAgentBridge.smoke.test.ts
+++ b/test/suite/smoke/mcpAgentBridge.smoke.test.ts
@@ -65,7 +65,7 @@ suite('Smoke: production MCP Agent Bridge', () => {
     try {
       await client.connect(transport);
       const listed = await client.listTools();
-      assert.strictEqual(listed.tools.length, 69);
+      assert.strictEqual(listed.tools.length, 73);
       assert.deepStrictEqual(
         listed.tools.map((tool) => tool.name),
         MCP_TOOL_CATALOG.map((tool) => tool.name),

--- a/test/suite/treeDataProvider.test.ts
+++ b/test/suite/treeDataProvider.test.ts
@@ -61,7 +61,7 @@ suite('MetadataTreeDataProvider Test Suite', () => {
     assert.ok(provider);
   });
 
-  test('support configuration overlay preserves exact root context and original icon', () => {
+  test('support configuration overlay preserves base root context tokens and original icon', () => {
     const configPath = path.resolve('support-config');
     const rootNode: TreeNode = {
       id: 'root',
@@ -84,7 +84,9 @@ suite('MetadataTreeDataProvider Test Suite', () => {
 
     const item = provider.getTreeItem(rootNode);
 
-    assert.strictEqual(item.contextValue, 'Configuration');
+    const contextTokens = item.contextValue?.split(/\s+/) ?? [];
+    assert.ok(contextTokens.includes('Configuration'));
+    assert.ok(contextTokens.includes('cfeBaseConfiguration'));
     assert.ok(item.iconPath instanceof vscode.ThemeIcon);
     assert.notStrictEqual((item.iconPath as vscode.ThemeIcon).id, 'lock');
     assert.ok(!String(item.description).includes('🔒'));

--- a/test/suite/treeItemBuilder.test.ts
+++ b/test/suite/treeItemBuilder.test.ts
@@ -39,22 +39,29 @@ function makeDeco(boundCount: number, massDeployment: boolean): ConfigurationBin
 }
 
 suite('buildTreeItem (#80 — bindingBound context value)', () => {
-  test('Configuration with boundCount>0, massDeployment:false → contextValue = "Configuration bindingBound deployOne"', () => {
+  test('base Configuration with boundCount>0, massDeployment:false has a stable base context token', () => {
     const node = makeNode({ type: MetadataType.Configuration });
     const item = buildTreeItem(node, makeOptions({ bindingDeco: makeDeco(1, false) }));
-    assert.strictEqual(item.contextValue, 'Configuration bindingBound deployOne');
+    assert.strictEqual(item.contextValue, 'Configuration cfeBaseConfiguration bindingBound deployOne');
   });
 
   test('Configuration with boundCount>0, massDeployment:true → contextValue = "Configuration bindingBound deployMany"', () => {
     const node = makeNode({ type: MetadataType.Configuration });
     const item = buildTreeItem(node, makeOptions({ bindingDeco: makeDeco(2, true) }));
-    assert.strictEqual(item.contextValue, 'Configuration bindingBound deployMany');
+    assert.strictEqual(item.contextValue, 'Configuration cfeBaseConfiguration bindingBound deployMany');
   });
 
-  test('Configuration without bindingDeco → contextValue = "Configuration"', () => {
+  test('base Configuration without bindingDeco has the base context token', () => {
     const node = makeNode({ type: MetadataType.Configuration });
     const item = buildTreeItem(node, makeOptions({}));
-    assert.strictEqual(item.contextValue, 'Configuration');
+    assert.strictEqual(item.contextValue, 'Configuration cfeBaseConfiguration');
+  });
+
+  test('CFE Configuration has no base context token', () => {
+    const node = makeNode({ type: MetadataType.Configuration, properties: { extensionPurpose: 'Customization' } });
+    const item = buildTreeItem(node, makeOptions({}));
+    assert.strictEqual(item.contextValue, 'Configuration cfeExtensionConfiguration');
+    assert.ok(!item.contextValue?.includes('cfeBaseConfiguration'));
   });
 
   test('Catalog (child node) with bindingDeco.boundCount>0 → contextValue = "Catalog bindingBound"', () => {


### PR DESCRIPTION
Закрывает #125.\n\nРеализовано: устойчивый CF↔CFE manifest/context, создание Designer XML CFE 2.17–2.21, безопасный staging/rollback/recovery, корректная nested CFE binding/deploy маршрутизация, UI и 4 Agent/MCP команды (73/73).\n\nПроверено: TypeScript/ESLint/diff-check; core suite 3305 passing; реальный round-trip 8.3.27: create → ibcmd import/apply base → import/apply extension → export extension.